### PR TITLE
feat(cad2d): complete geometry consistency validation milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,52 +6,41 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Highlights
-- **New cad2d topology core**: Introduced a fully re-designed, OCCT-free 2D topology layer with builders, validators, and comprehensive test coverage.
-- **Validation-first architecture**: Topology invariants are now explicitly checked via a dedicated validation module, enabling early error detection and safer future geometry integration.
-- **cad2d geometry binding introduced**: Added the first geometry integration layer via curve storage and geometry-aware half-edge construction, without exposing OCCT in topology.
+- **Geometry consistency validation completed for cad2d**: Finished the full vNext geometry-validation milestone, including vertex–curve agreement checks, curve-domain and degeneracy validation, optional shape-level geometry validation, and standardised diagnostic behaviour.
+- **Validation diagnostics strengthened**: Geometry validation now uses stable error-code mappings and consistent message prefixes, with targeted tests locking down representative diagnostic cases.
+- **Project-wide feature-config propagation introduced**: Added a generated configuration-header path so build-time feature macros such as `TONB_WITH_OCCT` can be propagated consistently through the codebase and tests.
 
 ### Added
-- **cad2d topology entities** (pure topology, no geometry kernel dependency):
-  - `Vertex`, `HalfEdge`, `Wire`, `Face`, and `Shape`
-  - Stable `Id` system and tolerance-aware point handling
-- **Builder layer (`cad2d/build`)**:
-  - `VartexBuilder`, `HalfEdgeBuilder`, `WireBuilder`, `FaceBuilder`
-  - Defensive construction using `Result<T>` with explicit error reporting
-- **Validation layer (`cad2d/validate`)**:
-  - Half-edge checks (endpoints, twin symmetry, next/prev consistency)
-  - Wire checks (boundary integrity, continuity, closure, next/prev vs boundary order)
-  - Face checks (outer/holes validity, edge disjointness)
-  - Shape checks (registry integrity and full topology validation)
-- **Result-based error handling**:
-  - Explicit `Result<T>` / `Result<void>` pattern across builders and validators
-  - Structured error codes and descriptive diagnostics
-- **GoogleTest test suite** for cad2d topology:
-  - Deterministic unit tests covering half-edges, wires, faces, and full shapes
-  - Negative test intentionally breaking invariants to verify validators
-  - Shared test helpers for building canonical square faces
-- **Geometry binding layer (`cad2d/geom`)**:
-  - `CurveStore` for owning and indexing `cad2d::Curve` objects behind stable topology ids
-  - Clear separation between pure topology and geometry-backed construction
-- **Geometry-aware builders**:
-  - Half-edge creation from geometry curves with validated parameter ranges and orientation 
-  - Twin half-edge creation bound to a single stored curve
-- **Geometry tests**:
-  - GoogleTest coverage for curve storage, retrieval, and geometry-aware half-edge construction
-  - Tests remain backend-safe (no OCCT leakage into cad2d topology)
+- **Geometry-aware half-edge validation**:
+    - validation of stored `curve_id`, `u0`, and `u1` against the referenced curve in `geom::CurveStore`
+    - endpoint agreement checks between evaluated curve points and half-edge start/end vertices
+    - curve-domain checks with tolerance-aware parameter validation
+    - degenerate-span detection for invalid zero-length parameter ranges
+    - orientation/parameter-order consistency checks for forward and reversed half-edges
+- **Shape-level optional geometry validation**:
+    - geometry checks can now be enabled from `validate::check_shape(...)` without changing topology-only behaviour
+    - missing or invalid curve bindings are now caught at shape-validation level when geometry validation is enabled
+- **Geometry validation diagnostic tests**:
+    - message-prefix and error-code assertions for representative geometry-validation failures
+    - validator-side out-of-domain tests using direct half-edge construction for corrupted/imported states
+    - strengthened regression coverage for endpoint mismatch, missing curve, domain violation, degeneracy, and orientation handling
+- **Generated Tonb config header path**:
+    - build-generated project configuration header for propagating feature macros such as `TONB_WITH_OCCT`
+    - unified feature-flag usage between library code and tests without local source-level macro definitions
 
 ### Changed
-- **cad2d architecture**:
-  - Clear separation between topology, builders, validation, and future geometry binding
-  - Topology is now independent of OCCT; geometry will be introduced in a higher layer
-- **Internal API discipline**:
-  - Consistent use of `std::shared_ptr` ownership and explicit `weak_ptr` links
-  - Deterministic validation order for reproducible diagnostics and tests
-- **cad2d build flow**:
-  - half-edge construction can now be driven directly from geometry curves while preserving topology purity.
+- **cad2d validation flow**:
+    - geometry validation is now treated as a first-class extension of the validation layer rather than only a builder-side safeguard
+    - manually created, imported, or corrupted half-edge states can now be rejected by validators even if builders would have prevented them at construction time
+- **Geometry validation diagnostics**:
+    - standardised message prefix for geometry-validation failures
+    - stable mapping of representative geometry failures onto existing `ErrorCode` categories
+- **Test configuration discipline**:
+    - tests now rely on configured build-time feature propagation instead of ad hoc local macro definitions for OCCT-enabled coverage
 
 ### Notes
-- This release establishes a **stable foundation** for upcoming geometry binding (`cad2d/geom`) and higher-level algorithms.
-- Geometry-dependent operations beyond curve binding (e.g., intersections, containment, trimming validation) are intentionally deferred and will build on the new geometry-aware topology foundation.
+- This completes **Milestone vNext — Geometry Consistency Validation (Option B)**.
+- The next planned milestone is **vNext+1 — Edge Abstraction (Topology Usability)**, introducing `topo::Edge` as the explicit owner of twin half-edge pairs.
 
 ## [0.19.0] - 2025-08-21
 ### Highlights
@@ -97,3 +86,4 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
   ```cmake
   find_package(tonb CONFIG REQUIRED)
   target_link_libraries(your_target PRIVATE tonb::system)
+  ```

--- a/libs/cad2d/CMakeLists.txt
+++ b/libs/cad2d/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(TonbCAD2d
         src/topo/wire.cxx
         src/topo/face.cxx
         src/topo/shape.cxx
+        src/topo/edge.cxx
         src/builder/vertex_builder.cxx
         src/builder/halfedge_builder.cxx
         src/builder/face_builder.cxx
@@ -65,6 +66,7 @@ target_sources(TonbCAD2d
         src/validate/shape_checks.cxx
         src/validate/geom_consistency.cxx
         src/validate/halfedge_geometry.cxx
+        src/validate/edge_checks.cxx
         src/geom/curve_store.cxx
         src/geom/curve_ops.cxx
         PUBLIC
@@ -92,6 +94,7 @@ target_sources(TonbCAD2d
         include/tonb/cad2d/topo/wire.hxx
         include/tonb/cad2d/topo/face.hxx
         include/tonb/cad2d/topo/shape.hxx
+        include/tonb/cad2d/topo/edge.hxx
         include/tonb/cad2d/builder/vertex_builder.hxx
         include/tonb/cad2d/builder/halfedge_builder.hxx
         include/tonb/cad2d/builder/face_builder.hxx
@@ -102,6 +105,7 @@ target_sources(TonbCAD2d
         include/tonb/cad2d/validate/shape_checks.hxx
         include/tonb/cad2d/validate/geom_consistency.hxx
         include/tonb/cad2d/validate/halfedge_geometry.hxx
+        include/tonb/cad2d/validate/edge_checks.hxx
         include/tonb/cad2d/geom/curve_store.hxx
         include/tonb/cad2d/geom/curve_ops.hxx
 )

--- a/libs/cad2d/include/tonb/cad2d/builder/halfedge_builder.hxx
+++ b/libs/cad2d/include/tonb/cad2d/builder/halfedge_builder.hxx
@@ -3,10 +3,14 @@
 //
 /**
  * @file halfedge_builder.hxx
- * @brief Declares the HalfEdgeBuilder class for constructing half-edges and pairs.
+ * @brief Declares the HalfEdgeBuilder class for constructing half-edges, pairs, and edge-owned twin pairs.
  *
  * HalfEdgeBuilder creates directed half-edges and sets basic connectivity
  * (start and end vertices). It also supports creating a twin pair in one call.
+ *
+ * In addition, this builder can now create a first-class topo::Edge object
+ * that owns two directed half-edges and establishes their twin relationship
+ * as an explicit topology invariant.
  *
  * Geometry binding remains abstract through curve ids and parametric spans.
  */
@@ -22,6 +26,7 @@
 namespace tonb::cad2d::geom {
     class CurveStore;
 }
+
 namespace tonb::cad2d::build {
 
     class HalfEdgeBuilder {
@@ -47,8 +52,13 @@ namespace tonb::cad2d::build {
          * @return Result containing the created half-edge.
          */
         TNBCAD2D_ND_EXPORT topo::Result<std::shared_ptr<topo::HalfEdge> > create(
-            const std::shared_ptr<topo::Vertex> &start, const std::shared_ptr<topo::Vertex> &end, topo::Id curveId,
-            double u0, double u1, topo::Orientation dir, double tol = 1.e-9) const;
+            const std::shared_ptr<topo::Vertex>& start,
+            const std::shared_ptr<topo::Vertex>& end,
+            topo::Id curveId,
+            double u0,
+            double u1,
+            topo::Orientation dir,
+            double tol = 1.e-9) const;
 
         /**
          * @brief Create a twin pair of half-edges (a directed edge in both directions).
@@ -67,8 +77,47 @@ namespace tonb::cad2d::build {
          * @return Result containing the pair (ab, ba).
          */
         TNBCAD2D_ND_EXPORT topo::Result<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge> > >
-        create_pair(const std::shared_ptr<topo::Vertex> &a, const std::shared_ptr<topo::Vertex> &b, topo::Id curveId,
-                    double u0, double u1, double tol = 1.e-9) const;
+        create_pair(const std::shared_ptr<topo::Vertex>& a,
+                    const std::shared_ptr<topo::Vertex>& b,
+                    topo::Id curveId,
+                    double u0,
+                    double u1,
+                    double tol = 1.e-9) const;
+
+        /**
+         * @brief Create a first-class topology edge that owns a twin half-edge pair.
+         *
+         * This function creates:
+         * - one topo::Edge object,
+         * - one forward half-edge from a to b,
+         * - one reverse half-edge from b to a,
+         * and establishes the ownership and twin invariants between them.
+         *
+         * The created edge guarantees:
+         * - both half-edges exist,
+         * - both half-edges reference the same curve id,
+         * - both half-edges use opposite orientations,
+         * - both half-edges are twin-linked to each other,
+         * - both half-edges reference the created topo::Edge as their owner.
+         *
+         * The forward half-edge uses (u0, u1) with forward orientation.
+         * The reverse half-edge uses (u1, u0) with reversed orientation.
+         *
+         * @param a First vertex.
+         * @param b Second vertex.
+         * @param curveId Opaque curve identifier.
+         * @param u0 Start parameter in the forward direction.
+         * @param u1 End parameter in the forward direction.
+         * @param tol Local tolerance for both half-edges.
+         * @return Result containing the created topology edge.
+         */
+        TNBCAD2D_ND_EXPORT topo::Result<std::shared_ptr<topo::Edge> > create_edge(
+            const std::shared_ptr<topo::Vertex>& a,
+            const std::shared_ptr<topo::Vertex>& b,
+            topo::Id curveId,
+            double u0,
+            double u1,
+            double tol = 1.e-9) const;
 
         /**
          * @brief Create a single half-edge by binding a cad2d::Curve through a CurveStore.
@@ -85,30 +134,76 @@ namespace tonb::cad2d::build {
          * @param end End vertex.
          * @param u0 Start parameter.
          * @param u1 End parameter.
-         * @param dir Orientation along curve (forward expects u0<u1, reversed expects u0?u1).
+         * @param dir Orientation along curve (forward expects u0<u1, reversed expects u0>u1).
          * @param tol local edge tolerance.
          * @param eps Parametric epsilon used for domain checks.
          */
         TNBCAD2D_ND_EXPORT topo::Result<std::shared_ptr<topo::HalfEdge> > create_from_curve(
-            geom::CurveStore &store, const Curve &curve, const std::shared_ptr<topo::Vertex> &start,
-            const std::shared_ptr<topo::Vertex> &end, real u0, real u1, topo::Orientation dir, real tol = 1.e-9,
+            geom::CurveStore& store,
+            const Curve& curve,
+            const std::shared_ptr<topo::Vertex>& start,
+            const std::shared_ptr<topo::Vertex>& end,
+            real u0,
+            real u1,
+            topo::Orientation dir,
+            real tol = 1.e-9,
             real eps = 1.e-12) const;
 
         /**
-         * @brief Create a twin pari by binding a cad2d::Curve through a CurveStore.
+         * @brief Create a twin pair by binding a cad2d::Curve through a CurveStore.
          *
          * This is equivalent to:
          *  - register curve once in store
-         *  - create_pair(...) using the retuned curve id
+         *  - create_pair(...) using the returned curve id
          *
          * The returned pair is (ab, ba). The reverse edge uses swapped parameters and reversed orientation.
          */
         TNBCAD2D_ND_EXPORT topo::Result<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge> > >
-        create_pair_from_curve(geom::CurveStore &store, const Curve &curve, const std::shared_ptr<topo::Vertex> &a,
-                               const std::shared_ptr<topo::Vertex> &b, real u0, real u1, real tol = 1.e-9,
+        create_pair_from_curve(geom::CurveStore& store,
+                               const Curve& curve,
+                               const std::shared_ptr<topo::Vertex>& a,
+                               const std::shared_ptr<topo::Vertex>& b,
+                               real u0,
+                               real u1,
+                               real tol = 1.e-9,
                                real eps = 1.e-12) const;
+
+        /**
+         * @brief Create a first-class topology edge by binding a cad2d::Curve through a CurveStore.
+         *
+         * This function:
+         * - validates that the curve is valid and bounded,
+         * - validates the forward parametric span,
+         * - registers the curve once in the store,
+         * - creates a topo::Edge whose owned half-edge pair share that curve id.
+         *
+         * The created edge owns:
+         * - a forward half-edge from a to b using (u0, u1),
+         * - a reverse half-edge from b to a using (u1, u0).
+         *
+         * @param store Geometry curve registry.
+         * @param curve Curve wrapper to bind.
+         * @param a First vertex.
+         * @param b Second vertex.
+         * @param u0 Start parameter in the forward direction.
+         * @param u1 End parameter in the forward direction.
+         * @param tol Local tolerance for both half-edges.
+         * @param eps Parametric epsilon used for domain checks.
+         * @return Result containing the created topology edge.
+         */
+        TNBCAD2D_ND_EXPORT topo::Result<std::shared_ptr<topo::Edge> > create_edge_from_curve(
+            geom::CurveStore& store,
+            const Curve& curve,
+            const std::shared_ptr<topo::Vertex>& a,
+            const std::shared_ptr<topo::Vertex>& b,
+            real u0,
+            real u1,
+            real tol = 1.e-9,
+            real eps = 1.e-12) const;
+
     private:
-      topo::Shape& shape_;
+        topo::Shape& shape_;
     };
 }
+
 #endif //TONB_CAD2D_BUILD_HALFEDGE_BUILDER_HXX

--- a/libs/cad2d/include/tonb/cad2d/topo/edge.hxx
+++ b/libs/cad2d/include/tonb/cad2d/topo/edge.hxx
@@ -1,0 +1,138 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file edge.hxx
+ * @brief Declares the Edge class, the first-class owner of a twin half-edge pair
+ *        in the cad2d topology layer.
+ *
+ * The cad2d topology model continues to use topo::HalfEdge as the directed
+ * traversal primitive for wires and faces. This file introduces topo::Edge as a
+ * stronger identity and ownership abstraction above the incidental twin
+ * relationship stored directly on individual half-edges.
+ *
+ * Design intent
+ * -------------
+ * A topological undirected edge should exist as a first-class object even when
+ * the model is traversed through directed half-edges. The Edge class therefore
+ * groups the two opposite half-edges that represent the same underlying
+ * topological edge and provides a stable identity for that pair.
+ *
+ * Responsibilities of Edge
+ * ------------------------
+ * - own the concept of the half-edge pair via forward/reverse references,
+ * - provide a stable identity distinct from either child half-edge id,
+ * - enable validators to treat edge invariants as stronger than ad hoc
+ *   half-edge twin symmetry,
+ * - support future algorithms that need explicit edge identity without scanning
+ *   or inferring pairs from half-edge links.
+ *
+ * Important scope note
+ * --------------------
+ * Edge does not duplicate the detailed directed state that already belongs to
+ * topo::HalfEdge. In particular, start/end vertices, local parameter range,
+ * next/prev links, and left-face adjacency remain properties of the half-edge.
+ * Edge only stores the pairing relation.
+ */
+#pragma once
+#ifndef TONB_CAD2D_TOPO_EDGE_HXX
+#define TONB_CAD2D_TOPO_EDGE_HXX
+
+#include <tonb/cad2d/topo/id.hxx>
+#include <tonb/cad2d/module.hxx>
+
+#include <memory>
+
+namespace tonb::cad2d::topo {
+
+    class HalfEdge;
+
+    /**
+     * @class Edge
+     * @brief First-class owner of a forward/reverse half-edge pair.
+     *
+     * Edge stores non-owning references to the two directed half-edges that form
+     * a single undirected topological edge. Lifetime is controlled by the owning
+     * topo::Shape, which stores both the Edge object itself and the HalfEdge
+     * objects referenced here.
+     *
+     * Invariants expected by builders and validators:
+     * - forward() and reverse() refer to distinct half-edge objects,
+     * - both half-edges point back to this Edge through HalfEdge::edge(),
+     * - the two half-edges are twins of one another,
+     * - they share the same curve id and opposite orientation,
+     * - they represent opposite directions of the same endpoint pair.
+     */
+    class Edge {
+    public:
+        /// @name Construction
+        /// @{
+
+        /**
+         * @brief Default constructor creating an empty edge with id = 0.
+         */
+        Edge() = default;
+
+        /**
+         * @brief Construct an edge with a stable identifier.
+         * @param id Stable unique identifier within the owning shape.
+         */
+        explicit Edge(const Id id) noexcept : id_(id) {}
+
+        /// @}
+
+        /// @name Identity
+        /// @{
+
+        /**
+         * @brief Return the stable unique identifier of this edge.
+         */
+        TNB_NODISCARD Id id() const noexcept { return id_; }
+
+        /// @}
+
+        /// @name Half-edge access
+        /// @{
+
+        /**
+         * @brief Return the designated forward half-edge.
+         *
+         * The term "forward" here is purely the stored slot name for one member of
+         * the pair. It does not impose any global geometric convention.
+         */
+        TNB_NODISCARD std::shared_ptr<HalfEdge> forward() const noexcept { return forward_.lock(); }
+
+        /**
+         * @brief Return the designated reverse half-edge.
+         */
+        TNB_NODISCARD std::shared_ptr<HalfEdge> reverse() const noexcept { return reverse_.lock(); }
+
+        /**
+         * @brief Store the forward half-edge reference.
+         * @param e Non-owning reference to the forward half-edge.
+         */
+        void set_forward(std::weak_ptr<HalfEdge> e) noexcept { forward_ = std::move(e); }
+
+        /**
+         * @brief Store the reverse half-edge reference.
+         * @param e Non-owning reference to the reverse half-edge.
+         */
+        void set_reverse(std::weak_ptr<HalfEdge> e) noexcept { reverse_ = std::move(e); }
+
+        /**
+         * @brief Return true if both half-edge slots currently resolve.
+         */
+        TNB_NODISCARD bool has_valid_pair() const noexcept {
+            return !forward_.expired() && !reverse_.expired();
+        }
+
+        /// @}
+
+    private:
+        Id id_{0};
+        std::weak_ptr<HalfEdge> forward_;
+        std::weak_ptr<HalfEdge> reverse_;
+    };
+}
+
+#endif // TONB_CAD2D_TOPO_EDGE_HXX

--- a/libs/cad2d/include/tonb/cad2d/topo/halfedge.hxx
+++ b/libs/cad2d/include/tonb/cad2d/topo/halfedge.hxx
@@ -28,6 +28,7 @@ namespace tonb::cad2d::topo {
     // Forward Declarations
     class Vertex;
     class Face;
+    class Edge;
 
     using Id = std::uint64_t;
 
@@ -100,6 +101,10 @@ namespace tonb::cad2d::topo {
 
         /// @name Topological links
         /// @{
+        ///
+
+        /// Return the owning topological edge, if one is assigned.
+        TNB_NODISCARD std::shared_ptr<Edge> edge() const noexcept {return edge_.lock();}
 
         /// Reference to the starting vertex (non-owning).
         TNB_NODISCARD std::shared_ptr<Vertex> start() const noexcept {return v_start_.lock();}
@@ -126,6 +131,12 @@ namespace tonb::cad2d::topo {
         void set_next(std::weak_ptr<HalfEdge> he) noexcept {next_ = std::move(he);}
         void set_prev(std::weak_ptr<HalfEdge> he) noexcept {prev_ = std::move(he);}
         void set_left_face(std::weak_ptr<Face> f) noexcept {left_face_ = std::move(f);}
+
+        /**
+         * @brief Assign the owning topological edge.
+         * @param e Non-owning reference to the owner edge.
+         */
+        void set_edge(std::weak_ptr<Edge> e) noexcept {edge_ = std::move(e);}
 
         /// @}
 
@@ -190,6 +201,7 @@ namespace tonb::cad2d::topo {
         std::weak_ptr<HalfEdge> next_;      ///< Next edge in boundary loop
         std::weak_ptr<HalfEdge> prev_;      ///< Previous edge in boundary loop
         std::weak_ptr<Face> left_face_;     ///< Adjacent face on the left
+        std::weak_ptr<Edge> edge_;
     };
 }
 #endif //TONB_CAD2D_TOPO_HALFEDGE_HXX

--- a/libs/cad2d/include/tonb/cad2d/topo/shape.hxx
+++ b/libs/cad2d/include/tonb/cad2d/topo/shape.hxx
@@ -47,6 +47,7 @@ namespace tonb::cad2d::topo {
     class HalfEdge;
     class Wire;
     class Face;
+    class Edge;
 
     /**
      * @class Shape
@@ -145,6 +146,13 @@ namespace tonb::cad2d::topo {
         TNBCAD2D_ND_EXPORT std::shared_ptr<HalfEdge> make_halfedge(Id curveId, double u0, double u1, Orientation dir, double tol = 1.e-9);
 
         /**
+         * @brief Create and register a new edge.
+         *
+         * @return Shared pointer to the newly created edge.
+         */
+        TNBCAD2D_ND_EXPORT std::shared_ptr<Edge> make_edge();
+
+        /**
          * @brief Create and register a new wire.
          *
          * @return Shared pointer to the newly created wire.
@@ -176,6 +184,12 @@ namespace tonb::cad2d::topo {
         TNBCAD2D_ND_EXPORT std::shared_ptr<HalfEdge> halfedge(Id id) const noexcept;
 
         /**
+         * @brief Get an Edge by Id.
+         * @return Shared pointer if found, otherwise nullptr.
+         */
+        TNBCAD2D_ND_EXPORT std::shared_ptr<Edge> edge(Id id) const noexcept;
+
+        /**
          * @brief Get a wire by Id.
          * @return Shared pointer if found, otherwise nullptr.
          */
@@ -201,6 +215,11 @@ namespace tonb::cad2d::topo {
          * @brief Return a snapshot list of all half-edges.
          */
         TNBCAD2D_ND_EXPORT std::vector<std::shared_ptr<HalfEdge>> halfedges() const;
+
+        /**
+         * @brief Return a snapshot list of all topological edges.
+         */
+        TNBCAD2D_ND_EXPORT std::vector<std::shared_ptr<Edge>> edges() const;
 
         /**
          * @brief Return a snapshot list of all wires.
@@ -234,6 +253,13 @@ namespace tonb::cad2d::topo {
          * @return True if removed, false if not found.
          */
         TNBCAD2D_ND_EXPORT bool erase_halfedge(Id id) noexcept;
+
+        /**
+         * @brief Remove an edge from the registry.
+         * @param id Edge identifier.
+         * @return True if removed, false if not found.
+         */
+        TNBCAD2D_ND_EXPORT bool erase_edge(Id id) noexcept;
 
         /**
          * @brief Remove a wire from the registry.
@@ -302,6 +328,7 @@ namespace tonb::cad2d::topo {
         std::unordered_map<Id, std::shared_ptr<HalfEdge>> halfedges_;
         std::unordered_map<Id, std::shared_ptr<Wire>> wires_;
         std::unordered_map<Id, std::shared_ptr<Face>> faces_;
+        std::unordered_map<Id, std::shared_ptr<Edge>> edges_;
     };
 }
 #endif //TONB_CAD2D_TOPO_SHAPE_HXX

--- a/libs/cad2d/include/tonb/cad2d/validate/edge_checks.hxx
+++ b/libs/cad2d/include/tonb/cad2d/validate/edge_checks.hxx
@@ -1,0 +1,57 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file edge_checks.hxx
+ * @brief Declares validation routines for topo::Edge.
+ *
+ * This module introduces validation of first-class edge invariants. Unlike the
+ * older half-edge-only view, topo::Edge expresses that two half-edges belong to
+ * the same undirected topological edge. Validators in this module therefore
+ * treat edge invariants as stronger than incidental twin symmetry.
+ */
+#pragma once
+#ifndef TONB_CAD2D_VALIDATE_EDGE_CHECKS_HXX
+#define TONB_CAD2D_VALIDATE_EDGE_CHECKS_HXX
+
+#include <tonb/cad2d/topo/result.hxx>
+#include <tonb/cad2d/module.hxx>
+
+#include <memory>
+
+namespace tonb::cad2d::topo {
+    class Edge;
+}
+
+namespace tonb::cad2d::validate {
+
+    /**
+     * @brief Validate the explicit owner/member relationship of a topo::Edge.
+     *
+     * The check verifies that:
+     * - the edge pointer is non-null,
+     * - forward() and reverse() both resolve,
+     * - they are distinct half-edge objects,
+     * - each half-edge points back to the same edge through HalfEdge::edge().
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<void> check_edge_membership(const std::shared_ptr<topo::Edge>& edge);
+
+    /**
+     * @brief Validate pair-level edge invariants between the owned half-edges.
+     *
+     * The check verifies that:
+     * - the pair is reciprocal through twin links,
+     * - endpoints reverse one another,
+     * - curve ids match,
+     * - orientations are opposite,
+     * - parameter spans are the reverse of one another.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<void> check_edge_pair(const std::shared_ptr<topo::Edge>& edge);
+
+    /**
+     * @brief Run full edge validation.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<void> check_edge(const std::shared_ptr<topo::Edge>& edge);
+}
+
+#endif // TONB_CAD2D_VALIDATE_EDGE_CHECKS_HXX

--- a/libs/cad2d/include/tonb/cad2d/validate/halfedge_checks.hxx
+++ b/libs/cad2d/include/tonb/cad2d/validate/halfedge_checks.hxx
@@ -1,8 +1,5 @@
-//
-// Created by amir on 1/24/26.
-//
 /**
- * @file halfedge_checks.hxx
+* @file halfedge_checks.hxx
  * @brief Topology-only validation routines for individual half-edges.
  *
  * This module contains the fundamental, non-geometric checks that establish
@@ -17,6 +14,7 @@
  * - start / end vertex references
  * - twin symmetry and basic twin compatibility
  * - next / prev reciprocity and self-link exclusion
+ * - optional owner-edge consistency when a topo::Edge back-reference exists
  *
  * The following concerns are deliberately out of scope here:
  *
@@ -100,6 +98,16 @@ namespace tonb::cad2d::validate {
      * @return Success if next/prev links are absent or structurally valid.
      */
     TNBCAD2D_ND_EXPORT topo::Result<void> check_next_prev(const std::shared_ptr<topo::HalfEdge>& e);
+
+    /**
+     * @brief Validate that the half-edge is consistent with its owning topo::Edge, if any.
+     *
+     * Missing edge ownership is allowed because isolated half-edges may still exist
+     * in intermediate modelling states. When an owner edge is present, however, the
+     * half-edge must appear as either the forward or reverse member of that edge, and
+     * its twin must be the sibling member stored there.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<void> check_edge_link(const std::shared_ptr<topo::HalfEdge>& e);
 
     /**
      * @brief Run the complete topology-only half-edge validation sequence.

--- a/libs/cad2d/include/tonb/cad2d/validate/shape_checks.hxx
+++ b/libs/cad2d/include/tonb/cad2d/validate/shape_checks.hxx
@@ -43,6 +43,7 @@ namespace tonb::cad2d::validate {
     struct ShapeCheckOptions {
         bool check_vertices = true;         ///< Reserved for future vertex-specific structural checks.
         bool check_halfedges = true;        ///< Run topology-only half-edge checks.
+        bool check_edges = true;            ///< Run first-class edge checks.
         bool check_wires = true;            ///< Run wire checks.
         bool check_faces = true;            ///< Run face checks.
         bool check_geometry = false;        ///< Run geometry-aware half-edge checks when a CurveStore is available.

--- a/libs/cad2d/src/builder/halfedge_builder.cxx
+++ b/libs/cad2d/src/builder/halfedge_builder.cxx
@@ -1,34 +1,44 @@
 //
 // Created by amir on 1/22/26.
 //
+/**
+ * @file halfedge_builder.cxx
+ * @brief Implements construction of half-edges and first-class topo::Edge pairs.
+ */
 
 #include <tonb/cad2d/builder/halfedge_builder.hxx>
 
+#include <sstream>
+#include <cmath>
+
 #include <tonb/cad2d/topo/vertex.hxx>
+#include <tonb/cad2d/topo/edge.hxx>
 #include <tonb/cad2d/curve.hxx>
 #include <tonb/cad2d/geom/curve_store.hxx>
 
 namespace tonb::cad2d::build {
-    topo::Result<std::shared_ptr<topo::HalfEdge>> HalfEdgeBuilder::create(const std::shared_ptr<topo::Vertex> &start,
-        const std::shared_ptr<topo::Vertex> &end, const topo::Id curveId, const double u0, const double u1,
+    topo::Result<std::shared_ptr<topo::HalfEdge>> HalfEdgeBuilder::create(
+        const std::shared_ptr<topo::Vertex>& start,
+        const std::shared_ptr<topo::Vertex>& end,
+        const topo::Id curveId,
+        const double u0,
+        const double u1,
         const topo::Orientation dir,
         const double tol) const {
+
         if (!start || !end) {
-            return topo::Result<std::shared_ptr<topo::HalfEdge>>(topo::ResultError{
-                "HalfEdgeBuilder: start or end vertex is null", topo::ErrorCode::invalid_input
-            });
+            return topo::fail<std::shared_ptr<topo::HalfEdge>>(
+                "HalfEdgeBuilder: start or end vertex is null", topo::ErrorCode::invalid_input);
         }
         if (start->id() == end->id()) {
-            return topo::Result<std::shared_ptr<topo::HalfEdge>>(topo::ResultError{
-                "HalfEdgeBuilder: start and end vertex must be distinct", topo::ErrorCode::degenerate
-            });
+            return topo::fail<std::shared_ptr<topo::HalfEdge>>(
+                "HalfEdgeBuilder: start and end vertex must be distinct", topo::ErrorCode::degenerate);
         }
 
         auto e = shape_.make_halfedge(curveId, u0, u1, dir, tol);
         if (!e) {
-            return topo::Result<std::shared_ptr<topo::HalfEdge>>(topo::ResultError{
-                "HalfEdgeBuilder: failed to allocate half-edge", topo::ErrorCode::internal
-            });
+            return topo::fail<std::shared_ptr<topo::HalfEdge>>(
+                "HalfEdgeBuilder: failed to allocate half-edge", topo::ErrorCode::internal);
         }
 
         e->set_start(start);
@@ -40,58 +50,33 @@ namespace tonb::cad2d::build {
         return topo::ok(std::move(e));
     }
 
-    topo::Result<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>> HalfEdgeBuilder::
-    create_pair(const std::shared_ptr<topo::Vertex> &a, const std::shared_ptr<topo::Vertex> &b, const topo::Id curveId,
-        const double u0, const double u1, const double tol) const {
-        auto ab = create(a, b, curveId, u0, u1, topo::Orientation::forward, tol);
-        if (!ab) return topo::Result<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<
-            topo::HalfEdge> > >(ab.error());
-
-        auto ba = create(b, a, curveId, u0, u1, topo::Orientation::reversed, tol);
-        if (!ba) return topo::Result<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<
-            topo::HalfEdge> > >(ba.error());
-
-        ab.value()->set_twin(ba.value());
-        ba.value()->set_twin(ab.value());
-
-        return topo::ok(std::make_pair(std::move(ab.value()), std::move(ba.value())));
-    }
-
     namespace {
         bool in_range(const real u, const real a, const real b, const real eps) {
-            // Accept slight epsilon overshoot to avoid numerical noise at endpoints.
             return (u >= a - eps && u <= b + eps);
         }
 
-        topo::Result<void> validate_curve_span(const Curve &curve, const real u0, const real u1,
+        topo::Result<void> validate_curve_span(const Curve& curve, const real u0, const real u1,
                                                const topo::Orientation dir, const real eps) {
             if (!curve.is_valid()) {
                 return topo::fail<void>("HalfEdgeBuilder: curve is not valid", topo::ErrorCode::geometry_error);
             }
-
             const auto rng = curve.parameter_range();
             if (!rng) {
                 return topo::fail<void>("HalfEdgeBuilder: curve is unbounded (parameter_range is empty)",
                                         topo::ErrorCode::geometry_error);
             }
-
             const real a = rng->first;
             const real b = rng->second;
-
             if (!in_range(u0, a, b, eps) || !in_range(u1, a, b, eps)) {
                 std::ostringstream oss;
-                oss << "HalfEdgeBuilder: parameters out of curve domain "
-                << "(u0=" << u0 << ", u1=" << u1 << ", domain=[" << a << "," << b << "])";
+                oss << "HalfEdgeBuilder: parameters out of curve domain (u0=" << u0 << ", u1=" << u1
+                    << ", domain=[" << a << "," << b << "])";
                 return topo::fail<void>(oss.str(), topo::ErrorCode::geometry_error);
             }
-
-            // Degeneracy
             if (std::abs(u1 - u0) < eps) {
                 return topo::fail<void>("HalfEdgeBuilder: degenerate param span (u0 and u1 are equal)",
                                         topo::ErrorCode::degenerate);
             }
-
-            // Enforce ordering by orientation to keep the model deterministic.
             if (dir == topo::Orientation::forward && !(u0 < u1)) {
                 return topo::fail<void>("HalfEdgeBuilder: forward edge expects u0 < u1",
                                         topo::ErrorCode::invalid_input);
@@ -100,67 +85,114 @@ namespace tonb::cad2d::build {
                 return topo::fail<void>("HalfEdgeBuilder: reversed edge expects u0 > u1",
                                         topo::ErrorCode::invalid_input);
             }
-            return {}; // success
+            return {};
         }
     }
 
-    topo::Result<std::shared_ptr<topo::HalfEdge>> HalfEdgeBuilder::create_from_curve(geom::CurveStore &store,
-        const Curve &curve, const std::shared_ptr<topo::Vertex> &start, const std::shared_ptr<topo::Vertex> &end,
-        const real u0, const real u1, const topo::Orientation dir, const real tol, const real eps) const {
-        if (!start || !end) {
-            return topo::fail<std::shared_ptr<topo::HalfEdge> >(
-                "HalfEdgeBuilder::create_from_curve: start/end vertex is null", topo::ErrorCode::invalid_input);
+    topo::Result<std::shared_ptr<topo::Edge>> HalfEdgeBuilder::create_edge(
+        const std::shared_ptr<topo::Vertex>& a,
+        const std::shared_ptr<topo::Vertex>& b,
+        const topo::Id curveId,
+        const double u0,
+        const double u1,
+        const double tol) const {
+
+        auto ab = create(a, b, curveId, u0, u1, topo::Orientation::forward, tol);
+        if (!ab) return topo::fail<std::shared_ptr<topo::Edge>>(ab.error().message, ab.error().code);
+
+        auto ba = create(b, a, curveId, u1, u0, topo::Orientation::reversed, tol);
+        if (!ba) return topo::fail<std::shared_ptr<topo::Edge>>(ba.error().message, ba.error().code);
+
+        auto edge = shape_.make_edge();
+        if (!edge) {
+            return topo::fail<std::shared_ptr<topo::Edge>>(
+                "HalfEdgeBuilder: failed to allocate topological edge", topo::ErrorCode::internal);
         }
 
-        // Validate geometry span first, before registering anything.
-        if (const auto ok = validate_curve_span(curve, u0, u1, dir, eps); !ok) {
-            return topo::fail<std::shared_ptr<topo::HalfEdge>>(ok.error().message, ok.error().code);
-        }
+        ab.value()->set_twin(ba.value());
+        ba.value()->set_twin(ab.value());
+        ab.value()->set_edge(edge);
+        ba.value()->set_edge(edge);
+        edge->set_forward(ab.value());
+        edge->set_reverse(ba.value());
 
-        topo::Id cid = 0;
-        try {
-            cid = store.add(curve);
-        } catch (const std::exception &e) {
+        return topo::ok(std::move(edge));
+    }
+
+    topo::Result<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>> HalfEdgeBuilder::create_pair(
+        const std::shared_ptr<topo::Vertex>& a,
+        const std::shared_ptr<topo::Vertex>& b,
+        const topo::Id curveId,
+        const double u0,
+        const double u1,
+        const double tol) const {
+
+        auto edge = create_edge(a, b, curveId, u0, u1, tol);
+        if (!edge) {
+            return topo::fail<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>>(
+                edge.error().message, edge.error().code);
+        }
+        return topo::ok(std::make_pair(edge.value()->forward(), edge.value()->reverse()));
+    }
+
+    topo::Result<std::shared_ptr<topo::HalfEdge>> HalfEdgeBuilder::create_from_curve(
+        geom::CurveStore& store,
+        const Curve& curve,
+        const std::shared_ptr<topo::Vertex>& start,
+        const std::shared_ptr<topo::Vertex>& end,
+        const real u0,
+        const real u1,
+        const topo::Orientation dir,
+        const real tol,
+        const real eps) const {
+
+        if (const auto r = validate_curve_span(curve, u0, u1, dir, eps); !r) {
+            return topo::fail<std::shared_ptr<topo::HalfEdge>>(r.error().message, r.error().code);
+        }
+        const auto curveId = store.add(curve);
+        if (curveId == 0) {
             return topo::fail<std::shared_ptr<topo::HalfEdge>>(
-            std::string("HalfEdgeBuilder::create_from_curve: failed to register curve: ") + e.what(),
-            topo::ErrorCode::internal
-                );
+                "HalfEdgeBuilder: CurveStore returned invalid curve id=0", topo::ErrorCode::internal);
         }
-
-        // Delegate to the pure topology creator.
-        return create(start, end, cid, u0, u1, dir, tol);
+        return create(start, end, curveId, u0, u1, dir, tol);
     }
 
-    topo::Result<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>> HalfEdgeBuilder::
-    create_pair_from_curve(geom::CurveStore &store, const Curve &curve, const std::shared_ptr<topo::Vertex> &a,
-        const std::shared_ptr<topo::Vertex> &b, real u0, real u1, real tol, real eps) const {
-        if (!a || !b) {
-            return topo::fail<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>>(
-            "HalfEdgeBuilder::create_pair_from_curve: vertex is null",
-            topo::ErrorCode::invalid_input
-                );
-        }
+    topo::Result<std::shared_ptr<topo::Edge>> HalfEdgeBuilder::create_edge_from_curve(
+        geom::CurveStore& store,
+        const Curve& curve,
+        const std::shared_ptr<topo::Vertex>& a,
+        const std::shared_ptr<topo::Vertex>& b,
+        const real u0,
+        const real u1,
+        const real tol,
+        const real eps) const {
 
-        // For the forward edge we assume forward orientation and u0<u1.
-        if (const auto ok = validate_curve_span(curve, u0, u1, topo::Orientation::forward, eps); !ok) {
-            return topo::fail<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>>(
-                ok.error().message, ok.error().code
-            );
+        if (const auto r = validate_curve_span(curve, u0, u1, topo::Orientation::forward, eps); !r) {
+            return topo::fail<std::shared_ptr<topo::Edge>>(r.error().message, r.error().code);
         }
-
-        topo::Id cid = 0;
-        try {
-            cid = store.add(curve);
-        } catch (const std::exception &e) {
-            return topo::fail<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>>(
-               std::string("HalfEdgeBuilder::create_pair_from_curve: failed to register curve: ") + e.what(),
-               topo::ErrorCode::internal
-           );
+        const auto curveId = store.add(curve);
+        if (curveId == 0) {
+            return topo::fail<std::shared_ptr<topo::Edge>>(
+                "HalfEdgeBuilder: CurveStore returned invalid curve id=0", topo::ErrorCode::internal);
         }
+        return create_edge(a, b, curveId, u0, u1, tol);
+    }
 
-        // Reuse the existing topology pair creator.
-        // It will create (ab, ba). The reverse edge parameters are handled there
-        // (if not, we will adjust it in that implementation).
-        return create_pair(a, b, cid, u0, u1, tol);
+    topo::Result<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>> HalfEdgeBuilder::create_pair_from_curve(
+        geom::CurveStore& store,
+        const Curve& curve,
+        const std::shared_ptr<topo::Vertex>& a,
+        const std::shared_ptr<topo::Vertex>& b,
+        const real u0,
+        const real u1,
+        const real tol,
+        const real eps) const {
+
+        auto edge = create_edge_from_curve(store, curve, a, b, u0, u1, tol, eps);
+        if (!edge) {
+            return topo::fail<std::pair<std::shared_ptr<topo::HalfEdge>, std::shared_ptr<topo::HalfEdge>>>(
+                edge.error().message, edge.error().code);
+        }
+        return topo::ok(std::make_pair(edge.value()->forward(), edge.value()->reverse()));
     }
 }

--- a/libs/cad2d/src/topo/edge.cxx
+++ b/libs/cad2d/src/topo/edge.cxx
@@ -1,0 +1,10 @@
+/**
+* @file edge.cxx
+ * @brief Translation unit for topo::Edge.
+ *
+ * The Edge type is intentionally lightweight and almost entirely inline in the
+ * header. This source file exists to give the module a dedicated implementation
+ * unit, preserve library structure symmetry, and provide a future home for any
+ * non-trivial edge operations should they be introduced later.
+ */
+#include <tonb/cad2d/topo/edge.hxx>

--- a/libs/cad2d/src/topo/shape.cxx
+++ b/libs/cad2d/src/topo/shape.cxx
@@ -1,12 +1,17 @@
 //
 // Created by amir on 1/22/26.
 //
+/**
+ * @file shape.cxx
+ * @brief Implements the Shape ownership registry for cad2d topology entities.
+ */
 #include <ranges>
 #include <tonb/cad2d/topo/shape.hxx>
 
 #include <tonb/cad2d/topo/vertex.hxx>
 #include <tonb/cad2d/topo/face.hxx>
 #include <tonb/cad2d/topo/halfedge.hxx>
+#include <tonb/cad2d/topo/edge.hxx>
 #include <tonb/cad2d/topo/wire.hxx>
 
 namespace tonb::cad2d::topo {
@@ -21,6 +26,13 @@ namespace tonb::cad2d::topo {
         const Id eid = ids_();
         const auto e = std::make_shared<HalfEdge>(eid, curveId, u0, u1, dir, tol);
         halfedges_.emplace(eid, e);
+        return e;
+    }
+
+    std::shared_ptr<Edge> Shape::make_edge() {
+        const Id eid = ids_();
+        const auto e = std::make_shared<Edge>(eid);
+        edges_.emplace(eid, e);
         return e;
     }
 
@@ -48,6 +60,11 @@ namespace tonb::cad2d::topo {
         return it == halfedges_.end() ? nullptr : it->second;
     }
 
+    std::shared_ptr<Edge> Shape::edge(const Id id) const noexcept {
+        const auto it = edges_.find(id);
+        return it == edges_.end() ? nullptr : it->second;
+    }
+
     std::shared_ptr<Wire> Shape::wire(const Id id) const noexcept {
         const auto it = wires_.find(id);
         return it == wires_.end() ? nullptr : it->second;
@@ -72,6 +89,13 @@ namespace tonb::cad2d::topo {
         return out;
     }
 
+    std::vector<std::shared_ptr<Edge>> Shape::edges() const {
+        std::vector<std::shared_ptr<Edge>> out;
+        out.reserve(edges_.size());
+        for (const auto& val : edges_ | std::views::values) out.push_back(val);
+        return out;
+    }
+
     std::vector<std::shared_ptr<Wire>> Shape::wires() const {
         std::vector<std::shared_ptr<Wire>> out;
         out.reserve(wires_.size());
@@ -86,67 +110,36 @@ namespace tonb::cad2d::topo {
         return out;
     }
 
-    bool Shape::erase_vertex(Id id) noexcept {
-        return vertices_.erase(id) > 0;
-    }
-
-    bool Shape::erase_halfedge(Id id) noexcept {
-        return halfedges_.erase(id) > 0;
-    }
-
-    bool Shape::erase_wire(Id id) noexcept {
-        return wires_.erase(id) > 0;
-    }
-
-    bool Shape::erase_face(Id id) noexcept {
-        return faces_.erase(id) > 0;
-    }
+    bool Shape::erase_vertex(Id id) noexcept { return vertices_.erase(id) > 0; }
+    bool Shape::erase_halfedge(Id id) noexcept { return halfedges_.erase(id) > 0; }
+    bool Shape::erase_edge(Id id) noexcept { return edges_.erase(id) > 0; }
+    bool Shape::erase_wire(Id id) noexcept { return wires_.erase(id) > 0; }
+    bool Shape::erase_face(Id id) noexcept { return faces_.erase(id) > 0; }
 
     Result<void> Shape::check_basic(const Tolerance &tol, bool requireClosed) const {
-        // Verify registries contain non-null pointers
         for (const auto& kv : vertices_) {
-            if (!kv.second) {
-                return Result<void>(ResultError{
-                    "shape basic check failed: a stored vertex pointer is null",
-                    ErrorCode::internal
-                });
-            }
+            if (!kv.second) return Result<void>(ResultError{"shape basic check failed: a stored vertex pointer is null", ErrorCode::internal});
         }
         for (const auto& kv: halfedges_) {
-            if (!kv.second) {
-                return Result<void>(ResultError{
-                    "Shape basic check failed: a stored half-edge pointer is null",
-                    ErrorCode::internal
-                });
-            }
+            if (!kv.second) return Result<void>(ResultError{"Shape basic check failed: a stored half-edge pointer is null", ErrorCode::internal});
+        }
+        for (const auto& kv: edges_) {
+            if (!kv.second) return Result<void>(ResultError{"Shape basic check failed: a stored edge pointer is null", ErrorCode::internal});
         }
         for (const auto& kv: wires_) {
-            if (!kv.second) {
-                return Result<void>(ResultError{
-                    "Shape basic check failed: a stored wire pointer is null",
-                    ErrorCode::internal
-                });
-            }
+            if (!kv.second) return Result<void>(ResultError{"Shape basic check failed: a stored wire pointer is null", ErrorCode::internal});
         }
         for (const auto& kv: faces_) {
-            if (!kv.second) {
-                return Result<void>(ResultError{
-                    "Shape basic check failed: a stored face pointer is null",
-                    ErrorCode::internal
-                });
-            }
+            if (!kv.second) return Result<void>(ResultError{"Shape basic check failed: a stored face pointer is null", ErrorCode::internal});
         }
-
-        // Verify each face has basic boundary integrity.
         for (const auto& kv: faces_) {
             const auto& f = kv.second;
             const auto r = f->check_basic(tol, requireClosed);
             if (!r) {
                 return Result<void>(ResultError{
                     "Shape basic check failed: face boundary check failed for face id=" + std::to_string(f->id()) +
-                        " (" + r.error().message + ")",
-                    r.error().code
-                });
+                    " (" + r.error().message + ")",
+                    r.error().code});
             }
         }
         return Result<void>{};

--- a/libs/cad2d/src/validate/edge_checks.cxx
+++ b/libs/cad2d/src/validate/edge_checks.cxx
@@ -1,0 +1,95 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file edge_checks.cxx
+ * @brief Implements validation routines for topo::Edge.
+ */
+
+#include <tonb/cad2d/validate/edge_checks.hxx>
+
+#include <tonb/cad2d/topo/vertex.hxx>
+#include <tonb/cad2d/topo/edge.hxx>
+#include <tonb/cad2d/topo/halfedge.hxx>
+#include <tonb/cad2d/topo/id.hxx>
+
+namespace tonb::cad2d::validate {
+    namespace {
+        std::string ctx(const std::shared_ptr<topo::Edge>& edge) {
+            if (!edge) return "EdgeChecks";
+            return "EdgeChecks (edge id=" + topo::to_string(edge->id()) + ")";
+        }
+
+        topo::Result<void> fail(std::string msg, const topo::ErrorCode code) {
+            return topo::Result<void>(topo::ResultError{std::move(msg), code});
+        }
+    }
+
+    topo::Result<void> check_edge_membership(const std::shared_ptr<topo::Edge>& edge) {
+        if (!edge) {
+            return fail("EdgeChecks: edge pointer is null", topo::ErrorCode::invalid_input);
+        }
+        const auto fwd = edge->forward();
+        const auto rev = edge->reverse();
+        if (!fwd) {
+            return fail(ctx(edge) + ": forward half-edge reference is missing or expired", topo::ErrorCode::topology_error);
+        }
+        if (!rev) {
+            return fail(ctx(edge) + ": reverse half-edge reference is missing or expired", topo::ErrorCode::topology_error);
+        }
+        if (fwd->id() == rev->id()) {
+            return fail(ctx(edge) + ": forward and reverse half-edges resolve to the same object", topo::ErrorCode::topology_error);
+        }
+        const auto fwd_owner = fwd->edge();
+        const auto rev_owner = rev->edge();
+        if (!fwd_owner || fwd_owner->id() != edge->id()) {
+            return fail(ctx(edge) + ": forward half-edge does not point back to the owning edge", topo::ErrorCode::topology_error);
+        }
+        if (!rev_owner || rev_owner->id() != edge->id()) {
+            return fail(ctx(edge) + ": reverse half-edge does not point back to the owning edge", topo::ErrorCode::topology_error);
+        }
+        return {};
+    }
+
+    topo::Result<void> check_edge_pair(const std::shared_ptr<topo::Edge>& edge) {
+        if (auto r = check_edge_membership(edge); !r) return r;
+
+        const auto fwd = edge->forward();
+        const auto rev = edge->reverse();
+        const auto tf = fwd->twin();
+        const auto tr = rev->twin();
+        if (!tf || tf->id() != rev->id()) {
+            return fail(ctx(edge) + ": forward half-edge twin does not resolve to the reverse half-edge", topo::ErrorCode::topology_error);
+        }
+        if (!tr || tr->id() != fwd->id()) {
+            return fail(ctx(edge) + ": reverse half-edge twin does not resolve to the forward half-edge", topo::ErrorCode::topology_error);
+        }
+
+        const auto a = fwd->start();
+        const auto b = fwd->end();
+        const auto c = rev->start();
+        const auto d = rev->end();
+        if (!a || !b || !c || !d) {
+            return fail(ctx(edge) + ": one or more endpoint references are missing while checking the pair", topo::ErrorCode::topology_error);
+        }
+        if (a->id() != d->id() || b->id() != c->id()) {
+            return fail(ctx(edge) + ": forward and reverse half-edges do not reverse the same endpoint pair", topo::ErrorCode::topology_error);
+        }
+        if (fwd->curve_id() != rev->curve_id()) {
+            return fail(ctx(edge) + ": half-edge pair uses different curve ids", topo::ErrorCode::topology_error);
+        }
+        if (fwd->orientation() == rev->orientation()) {
+            return fail(ctx(edge) + ": half-edge pair stores the same orientation on both directions", topo::ErrorCode::topology_error);
+        }
+        if (!(fwd->u0() == rev->u1() && fwd->u1() == rev->u0())) {
+            return fail(ctx(edge) + ": half-edge pair does not carry reversed parameter spans", topo::ErrorCode::topology_error);
+        }
+        return {};
+    }
+
+    topo::Result<void> check_edge(const std::shared_ptr<topo::Edge>& edge) {
+        if (auto r = check_edge_membership(edge); !r) return r;
+        if (auto r = check_edge_pair(edge); !r) return r;
+        return {};
+    }
+}

--- a/libs/cad2d/src/validate/halfedge_checks.cxx
+++ b/libs/cad2d/src/validate/halfedge_checks.cxx
@@ -9,6 +9,7 @@
 
 #include <tonb/cad2d/topo/halfedge.hxx>
 #include <tonb/cad2d/topo/vertex.hxx>
+#include <tonb/cad2d/topo/edge.hxx>
 #include <tonb/cad2d/topo/orientation.hxx>
 #include <tonb/cad2d/topo/id.hxx>
 
@@ -115,10 +116,37 @@ namespace tonb::cad2d::validate {
         return {};
     }
 
+    topo::Result<void> check_edge_link(const std::shared_ptr<topo::HalfEdge>& e) {
+        if (!e) {
+            return fail("HalfEdgeChecks: half-edge pointer is null", topo::ErrorCode::invalid_input);
+        }
+        const auto owner = e->edge();
+        if (!owner) {
+            return {};
+        }
+        const auto fwd = owner->forward();
+        const auto rev = owner->reverse();
+        if (!fwd || !rev) {
+            return fail(ctx(e) + ": owning topo::Edge does not resolve a complete half-edge pair", topo::ErrorCode::topology_error);
+        }
+        const bool is_forward = (fwd->id() == e->id());
+        const bool is_reverse = (rev->id() == e->id());
+        if (!is_forward && !is_reverse) {
+            return fail(ctx(e) + ": half-edge points to an owning topo::Edge that does not contain it", topo::ErrorCode::topology_error);
+        }
+        const auto t = e->twin();
+        const auto sibling = is_forward ? rev : fwd;
+        if (!t || t->id() != sibling->id()) {
+            return fail(ctx(e) + ": half-edge twin is inconsistent with the sibling stored in its owner edge", topo::ErrorCode::topology_error);
+        }
+        return {};
+    }
+
     topo::Result<void> check_halfedge(const std::shared_ptr<topo::HalfEdge>& e) {
         if (auto r = check_endpoints(e); !r) return r;
         if (auto r = check_twin(e); !r) return r;
         if (auto r = check_next_prev(e); !r) return r;
+        if (auto r = check_edge_link(e); !r) return r;
         return {};
     }
 }

--- a/libs/cad2d/src/validate/shape_checks.cxx
+++ b/libs/cad2d/src/validate/shape_checks.cxx
@@ -8,6 +8,7 @@
 #include <tonb/cad2d/validate/shape_checks.hxx>
 
 #include <tonb/cad2d/validate/halfedge_checks.hxx>
+#include <tonb/cad2d/validate/edge_checks.hxx>
 #include <tonb/cad2d/validate/wire_checks.hxx>
 #include <tonb/cad2d/validate/face_checks.hxx>
 #include <tonb/cad2d/validate/halfedge_geometry.hxx>
@@ -15,13 +16,13 @@
 #include <tonb/cad2d/topo/shape.hxx>
 #include <tonb/cad2d/topo/vertex.hxx>
 #include <tonb/cad2d/topo/halfedge.hxx>
+#include <tonb/cad2d/topo/edge.hxx>
 #include <tonb/cad2d/topo/wire.hxx>
 #include <tonb/cad2d/topo/face.hxx>
 #include <tonb/cad2d/topo/id.hxx>
 
 namespace tonb::cad2d::validate {
     namespace {
-
         std::string ctx(const topo::Shape& shape) {
             return "ShapeChecks (shape id=" + topo::to_string(shape.id()) + ")";
         }
@@ -64,6 +65,7 @@ namespace tonb::cad2d::validate {
                                             const ShapeCheckOptions& opt) {
             const auto vertices = shape.vertices();
             const auto halfedges = shape.halfedges();
+            const auto edges = shape.edges();
             const auto wires = shape.wires();
             const auto faces = shape.faces();
 
@@ -75,14 +77,21 @@ namespace tonb::cad2d::validate {
                 if (auto r = check_no_nulls(shape, halfedges, "half-edge"); !r) return r;
                 for (const auto& e : halfedges) {
                     if (auto r = check_halfedge(e); !r) {
-                        return fail(ctx(shape) + ": half-edge validation failed (" + r.error().message + ")",
-                                    r.error().code);
+                        return fail(ctx(shape) + ": half-edge validation failed (" + r.error().message + ")", r.error().code);
                     }
                     if (opt.check_geometry && store != nullptr) {
                         if (auto r = check_halfedge_geometry(e, *store, tol); !r) {
-                            return fail(ctx(shape) + ": half-edge geometry validation failed (" + r.error().message + ")",
-                                        r.error().code);
+                            return fail(ctx(shape) + ": half-edge geometry validation failed (" + r.error().message + ")", r.error().code);
                         }
+                    }
+                }
+            }
+
+            if (opt.check_edges) {
+                if (auto r = check_no_nulls(shape, edges, "edge"); !r) return r;
+                for (const auto& edge : edges) {
+                    if (auto r = check_edge(edge); !r) {
+                        return fail(ctx(shape) + ": edge validation failed (" + r.error().message + ")", r.error().code);
                     }
                 }
             }
@@ -91,8 +100,7 @@ namespace tonb::cad2d::validate {
                 if (auto r = check_no_nulls(shape, wires, "wire"); !r) return r;
                 for (const auto& w : wires) {
                     if (auto r = check_wire(w, tol, opt.require_closed_wires, opt.verify_open_wire_ends); !r) {
-                        return fail(ctx(shape) + ": wire validation failed (" + r.error().message + ")",
-                                    r.error().code);
+                        return fail(ctx(shape) + ": wire validation failed (" + r.error().message + ")", r.error().code);
                     }
                 }
             }
@@ -101,8 +109,7 @@ namespace tonb::cad2d::validate {
                 if (auto r = check_no_nulls(shape, faces, "face"); !r) return r;
                 for (const auto& f : faces) {
                     if (auto r = check_face(f, tol, opt.require_closed_wires); !r) {
-                        return fail(ctx(shape) + ": face validation failed (" + r.error().message + ")",
-                                    r.error().code);
+                        return fail(ctx(shape) + ": face validation failed (" + r.error().message + ")", r.error().code);
                     }
                 }
             }
@@ -111,15 +118,11 @@ namespace tonb::cad2d::validate {
         }
     }
 
-    topo::Result<void> check_shape(const topo::Shape& shape,
-                                   const topo::Tolerance& tol,
-                                   const ShapeCheckOptions& opt) {
+    topo::Result<void> check_shape(const topo::Shape& shape, const topo::Tolerance& tol, const ShapeCheckOptions& opt) {
         return check_shape_impl(shape, nullptr, tol, opt);
     }
 
-    topo::Result<void> check_shape(const topo::Shape& shape,
-                                   const geom::CurveStore& store,
-                                   const topo::Tolerance& tol,
+    topo::Result<void> check_shape(const topo::Shape& shape, const geom::CurveStore& store, const topo::Tolerance& tol,
                                    const ShapeCheckOptions& opt) {
         return check_shape_impl(shape, &store, tol, opt);
     }

--- a/tests/cad2d/CMakeLists.txt
+++ b/tests/cad2d/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(test_cad2d_validate
         geom_curve_store_tests.cxx
         halfedge_builder_geometry_tests.cxx
         halfedge_geometry_validation_tests.cxx
+        edge_builder_tests.cxx
+        edge_validation_tests.cxx
 )
 
 target_link_libraries(test_cad2d_validate PRIVATE

--- a/tests/cad2d/edge_builder_tests.cxx
+++ b/tests/cad2d/edge_builder_tests.cxx
@@ -1,0 +1,56 @@
+/**
+* @file edge_builder_tests.cxx
+ * @brief Tests first-class topo::Edge construction.
+ */
+#include <gtest/gtest.h>
+
+#include <tonb/config.hxx>
+#include <tonb/cad2d/topo/shape.hxx>
+#include <tonb/cad2d/topo/edge.hxx>
+#include <tonb/cad2d/topo/halfedge.hxx>
+#include <tonb/cad2d/builder/halfedge_builder.hxx>
+#include <tonb/cad2d/validate/edge_checks.hxx>
+#include <tonb/cad2d/tools.hxx>
+#include <tonb/cad2d/geom/curve_store.hxx>
+
+namespace tonb::cad2d::tests {
+
+    TEST(Cad2dBuild, EdgeCreateFromCurveCreatesTwinOwnedPair)
+    {
+#if !defined(TONB_WITH_OCCT)
+        GTEST_SKIP() << "TONB_WITH_OCCT disabled; skipping edge builder tests.";
+#else
+        topo::Shape shape;
+        build::HalfEdgeBuilder hb(shape);
+        geom::CurveStore store;
+
+        auto a = shape.make_vertex({0.0, 0.0});
+        auto b = shape.make_vertex({1.0, 0.0});
+        ASSERT_TRUE(a);
+        ASSERT_TRUE(b);
+
+        const cad2d::Curve c = cad2d::Tools::make_segment({0.0, 0.0}, {1.0, 0.0});
+        ASSERT_TRUE(c.is_valid());
+        const auto rng = c.parameter_range();
+        ASSERT_TRUE(rng.has_value());
+
+        auto edge = hb.create_edge_from_curve(store, c, a, b, rng->first, rng->second);
+        ASSERT_TRUE(edge) << edge.error().message;
+
+        const auto fwd = edge.value()->forward();
+        const auto rev = edge.value()->reverse();
+        ASSERT_TRUE(fwd);
+        ASSERT_TRUE(rev);
+        EXPECT_EQ(fwd->twin()->id(), rev->id());
+        EXPECT_EQ(rev->twin()->id(), fwd->id());
+        ASSERT_TRUE(fwd->edge());
+        ASSERT_TRUE(rev->edge());
+        EXPECT_EQ(fwd->edge()->id(), edge.value()->id());
+        EXPECT_EQ(rev->edge()->id(), edge.value()->id());
+
+        auto vr = validate::check_edge(edge.value());
+        ASSERT_TRUE(vr) << vr.error().message;
+#endif
+    }
+
+} // namespace tonb::cad2d::tests

--- a/tests/cad2d/edge_validation_tests.cxx
+++ b/tests/cad2d/edge_validation_tests.cxx
@@ -1,0 +1,51 @@
+/**
+* @file edge_validation_tests.cxx
+ * @brief Tests validation of topo::Edge invariants.
+ */
+#include <gtest/gtest.h>
+
+#include <tonb/config.hxx>
+#include <tonb/cad2d/topo/shape.hxx>
+#include <tonb/cad2d/topo/edge.hxx>
+#include <tonb/cad2d/topo/halfedge.hxx>
+#include <tonb/cad2d/builder/halfedge_builder.hxx>
+#include <tonb/cad2d/validate/edge_checks.hxx>
+#include <tonb/cad2d/tools.hxx>
+#include <tonb/cad2d/geom/curve_store.hxx>
+
+namespace tonb::cad2d::tests {
+
+    TEST(Cad2dValidateEdge, BreakingTwinFailsEdgeValidation)
+    {
+#if !defined(TONB_WITH_OCCT)
+        GTEST_SKIP() << "TONB_WITH_OCCT disabled; skipping edge validation tests.";
+#else
+        topo::Shape shape;
+        build::HalfEdgeBuilder hb(shape);
+        geom::CurveStore store;
+
+        auto a = shape.make_vertex({0.0, 0.0});
+        auto b = shape.make_vertex({1.0, 0.0});
+        ASSERT_TRUE(a);
+        ASSERT_TRUE(b);
+
+        const cad2d::Curve c = cad2d::Tools::make_segment({0.0, 0.0}, {1.0, 0.0});
+        ASSERT_TRUE(c.is_valid());
+        const auto rng = c.parameter_range();
+        ASSERT_TRUE(rng.has_value());
+
+        auto edge = hb.create_edge_from_curve(store, c, a, b, rng->first, rng->second);
+        ASSERT_TRUE(edge) << edge.error().message;
+
+        const auto fwd = edge.value()->forward();
+        ASSERT_TRUE(fwd);
+        fwd->set_twin(std::weak_ptr<topo::HalfEdge>{});
+
+        const auto vr = validate::check_edge(edge.value());
+        ASSERT_FALSE(vr);
+        EXPECT_EQ(vr.error().code, topo::ErrorCode::topology_error);
+        EXPECT_NE(vr.error().message.find("EdgeChecks"), std::string::npos);
+#endif
+    }
+
+} // namespace tonb::cad2d::tests

--- a/tests/cad2d/halfedge_geometry_validation_tests.cxx
+++ b/tests/cad2d/halfedge_geometry_validation_tests.cxx
@@ -11,7 +11,7 @@
  */
 #include <gtest/gtest.h>
 
-#define TONB_WITH_OCCT
+#include <tonb/config.hxx>
 #include <tonb/cad2d/tools.hxx>
 #include <tonb/cad2d/geom/curve_store.hxx>
 #include <tonb/cad2d/validate/halfedge_geometry.hxx>


### PR DESCRIPTION
- finish geometry-aware half-edge validation for vertex–curve agreement
- add validator-side checks for curve domain, degenerate span, and orientation consistency
- integrate optional geometry validation into shape checks without changing default topology-only behaviour
- standardise geometry-validation diagnostics using stable error-code mappings and consistent message prefixes
- strengthen tests for endpoint mismatch, missing curve, out-of-domain parameters, degeneracy, and diagnostic conventions
- add generated project config header support to propagate TONB_WITH_OCCT consistently through code and tests