### PR TITLE
feat(cad2d): add wire-length utility backed by public numerics arc-le…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - **Geometry consistency validation completed for cad2d**: Finished the full vNext geometry-validation milestone, including vertex–curve agreement checks, curve-domain and degeneracy validation, optional shape-level geometry validation, and standardised diagnostic behaviour.
 - **Validation diagnostics strengthened**: Geometry validation now uses stable error-code mappings and consistent message prefixes, with targeted tests locking down representative diagnostic cases.
 - **Project-wide feature-config propagation introduced**: Added a generated configuration-header path so build-time feature macros such as `TONB_WITH_OCCT` can be propagated consistently through the codebase and tests.
+- **Wire geometric length utility introduced**: Added a geometry-aware wire-length algorithm in `cad2d/algo`, backed by a public robust arc-length integration API in `numerics`.
 
 ### Added
 - **Geometry-aware half-edge validation**:
@@ -27,6 +28,15 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - **Generated Tonb config header path**:
     - build-generated project configuration header for propagating feature macros such as `TONB_WITH_OCCT`
     - unified feature-flag usage between library code and tests without local source-level macro definitions
+- **Public numerics arc-length integration API**:
+    - adaptive arc-length integration for planar parametric curves exposed as a public numerics facility
+    - deterministic, tolerance-driven refinement with explicit work limits and convergence metadata
+    - intended for reuse by higher-level CAD and geometry algorithms
+- **Wire length utility in `cad2d/algo`**:
+    - geometric wire-length computation by summing per-half-edge arc lengths from `curve_id`, `u0`, and `u1`
+    - explicit failure reporting for missing curves, invalid parameters, non-finite spans, and unsupported unbounded domains
+- **Wire-length test coverage**:
+    - regression test verifying that a square built from segment edges returns a total length of approximately 4 within tolerance
 
 ### Changed
 - **cad2d validation flow**:
@@ -37,10 +47,15 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - stable mapping of representative geometry failures onto existing `ErrorCode` categories
 - **Test configuration discipline**:
     - tests now rely on configured build-time feature propagation instead of ad hoc local macro definitions for OCCT-enabled coverage
+- **Numerical integration layering**:
+    - robust arc-length integration is now exposed from `numerics` as a public reusable API rather than being embedded privately inside `cad2d`
+- **cad2d algorithm layering**:
+    - wire-length computation is implemented as an algorithm-layer consumer of topology, geometry storage, and public numerics utilities
 
 ### Notes
 - This completes **Milestone vNext — Geometry Consistency Validation (Option B)**.
-- The next planned milestone is **vNext+1 — Edge Abstraction (Topology Usability)**, introducing `topo::Edge` as the explicit owner of twin half-edge pairs.
+- This also completes **Milestone vNext+2 — Wire Geometry Utilities**, introducing the first wire-level geometric utility.
+- The next planned milestone is **vNext+3 — Face Geometry Basics**, beginning with signed-area and orientation utilities.
 
 ## [0.19.0] - 2025-08-21
 ### Highlights

--- a/libs/cad2d/CMakeLists.txt
+++ b/libs/cad2d/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(TonbCAD2d
         src/validate/edge_checks.cxx
         src/geom/curve_store.cxx
         src/geom/curve_ops.cxx
+        src/algo/wire_length.cxx
         PUBLIC
         FILE_SET HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -108,6 +109,7 @@ target_sources(TonbCAD2d
         include/tonb/cad2d/validate/edge_checks.hxx
         include/tonb/cad2d/geom/curve_store.hxx
         include/tonb/cad2d/geom/curve_ops.hxx
+        include/tonb/cad2d/algo/wire_length.hxx
 )
 
 # Backend-specific sources
@@ -134,6 +136,7 @@ target_include_directories(TonbCAD2d PUBLIC
 target_link_libraries(TonbCAD2d
         PUBLIC Tonb::Geometry
         PUBLIC Tonb::Base
+        PUBLIC Tonb::Numerics
         PUBLIC Tonb::System
 )
 

--- a/libs/cad2d/include/tonb/cad2d/algo/wire_length.hxx
+++ b/libs/cad2d/include/tonb/cad2d/algo/wire_length.hxx
@@ -1,0 +1,68 @@
+/**
+ * @file wire_length.hxx
+ * @brief Declares geometric length utilities for cad2d wires.
+ *
+ * This module provides a geometry-aware utility that computes the total length
+ * of a topological wire by summing the arc lengths of its boundary half-edge
+ * spans.
+ *
+ * Architectural intent
+ * --------------------
+ * - topology ownership remains in cad2d/topo,
+ * - geometry lookup remains in cad2d/geom,
+ * - numerical integration remains in tonb::numerics,
+ * - this module performs only the algorithmic orchestration required to bridge
+ *   those layers.
+ *
+ * The implementation is intentionally defensive:
+ * - missing or expired half-edges fail with Result error information,
+ * - missing curve ids fail,
+ * - unbounded or non-finite curve domains fail,
+ * - non-converged numerical integration fails with a descriptive diagnostic.
+ */
+#pragma once
+#ifndef TONB_CAD2D_ALGO_WIRE_LENGTH_HXX
+#define TONB_CAD2D_ALGO_WIRE_LENGTH_HXX
+
+#include <tonb/cad2d/module.hxx>
+#include <tonb/cad2d/topo/result.hxx>
+#include <tonb/base/precision.hxx>
+#include <tonb/numerics/arc_length_integration.hxx>
+
+#include <memory>
+
+namespace tonb::cad2d::topo {
+    class Wire;
+}
+
+namespace tonb::cad2d::geom {
+    class CurveStore;
+}
+
+namespace tonb::cad2d::algo {
+
+    /**
+     * @brief Configuration for wire-length estimation.
+     *
+     * The numerical controls are delegated directly to the public arc-length
+     * integration API in tonb::numerics.
+     */
+    struct WireLengthOptions {
+        numerics::ArcLengthOptions integration{};
+    };
+
+    /**
+     * @brief Compute the total geometric length of a wire.
+     *
+     * @param wire Wire whose boundary length will be measured.
+     * @param curves Geometry registry used to resolve half-edge curve ids.
+     * @param options Numerical integration controls.
+     * @return Total wire length on success; failure diagnostic otherwise.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<real> wire_length(
+        const std::shared_ptr<topo::Wire>& wire,
+        const geom::CurveStore& curves,
+        const WireLengthOptions& options = {});
+}
+
+#endif // TONB_CAD2D_ALGO_WIRE_LENGTH_HXX

--- a/libs/cad2d/src/algo/wire_length.cxx
+++ b/libs/cad2d/src/algo/wire_length.cxx
@@ -1,0 +1,135 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file wire_length.cxx
+ * @brief Implements geometric length utilities for cad2d wires.
+ *
+ * This implementation computes wire length as the sum of arc lengths of all
+ * boundary half-edge spans. Each span is measured against its referenced curve
+ * using the public adaptive arc-length integrator provided by tonb::numerics.
+ */
+#include <tonb/cad2d/algo/wire_length.hxx>
+
+#include <tonb/cad2d/topo/wire.hxx>
+#include <tonb/cad2d/topo/halfedge.hxx>
+#include <tonb/cad2d/geom/curve_store.hxx>
+#include <tonb/cad2d/geom/curve_ops.hxx>
+#include <tonb/cad2d/point.hxx>
+#include <tonb/numerics/arc_length_integration.hxx>
+
+#include <sstream>
+#include <array>
+#include <cmath>
+
+namespace tonb::cad2d::algo {
+    namespace {
+
+        std::string ctx(const std::shared_ptr<topo::Wire>& wire) {
+            if (!wire) {
+                return "WireLength";
+            }
+            return "WireLength (wire id=" + std::to_string(wire->id()) + ")";
+        }
+
+        bool finite(const real x) noexcept {
+            return std::isfinite(x) != 0;
+        }
+
+        topo::Result<real> edge_length(const std::shared_ptr<topo::HalfEdge>& edge,
+                                       const geom::CurveStore& curves,
+                                       const WireLengthOptions& options) {
+            if (!edge) {
+                return topo::Result<real>(topo::ResultError{
+                    "WireLength: boundary contains a null or expired half-edge",
+                    topo::ErrorCode::topology_error
+                });
+            }
+
+            const auto curve_id = edge->curve_id();
+            if (curve_id == 0) {
+                return topo::Result<real>(topo::ResultError{
+                    "WireLength: half-edge stores invalid curve id 0",
+                    topo::ErrorCode::geometry_error
+                });
+            }
+
+            if (!curves.contains(curve_id)) {
+                return topo::Result<real>(topo::ResultError{
+                    "WireLength: referenced curve id is not present in CurveStore",
+                    topo::ErrorCode::geometry_error
+                });
+            }
+
+            const auto& curve = curves.get(curve_id);
+            const auto dom = geom::domain(curve);
+            if (!finite(dom.first) || !finite(dom.second)) {
+                return topo::Result<real>(topo::ResultError{
+                    "WireLength: curve domain is not finite; unbounded curves are not supported",
+                    topo::ErrorCode::geometry_error
+                });
+            }
+
+            const real u0 = edge->u0();
+            const real u1 = edge->u1();
+            if (!finite(u0) || !finite(u1)) {
+                return topo::Result<real>(topo::ResultError{
+                    "WireLength: half-edge parameters are not finite",
+                    topo::ErrorCode::geometry_error
+                });
+            }
+
+            auto eval = [&curve](const real u) -> std::array<real, 2> {
+                const auto p = geom::value(curve, u);
+                return {p.x(), p.y()};
+            };
+
+            const auto r = tonb::numerics::integrate_arc_length(eval, u0, u1, options.integration);
+            if (!r.converged) {
+                std::ostringstream oss;
+                oss << "WireLength: arc-length integration failed for edge id=" << edge->id()
+                    << " (reason=" << static_cast<int>(r.reason)
+                    << ", evals=" << r.evals
+                    << ", error_est=" << r.error_est
+                    << ")";
+                return topo::Result<real>(topo::ResultError{
+                    oss.str(),
+                    topo::ErrorCode::validation_failed
+                });
+            }
+
+            return topo::ok(static_cast<real>(r.value));
+        }
+    }
+
+    topo::Result<real> wire_length(const std::shared_ptr<topo::Wire>& wire,
+                                   const geom::CurveStore& curves,
+                                   const WireLengthOptions& options) {
+        if (!wire) {
+            return topo::Result<real>(topo::ResultError{
+                "WireLength: wire pointer is null",
+                topo::ErrorCode::invalid_input
+            });
+        }
+
+        if (wire->empty()) {
+            return topo::ok(real(0.0));
+        }
+
+        real sum = 0.0;
+        const auto edges = wire->edges_locked();
+        for (std::size_t i = 0; i < edges.size(); ++i) {
+            const auto ri = edge_length(edges[i], curves, options);
+            if (!ri) {
+                return topo::Result<real>(topo::ResultError{
+                    ctx(wire) + ": failed on boundary edge index " + std::to_string(i) +
+                    " (" + ri.error().message + ")",
+                    ri.error().code
+                });
+            }
+            sum += ri.value();
+        }
+
+        return topo::ok(static_cast<real>(sum));
+    }
+}

--- a/libs/mesh/CMakeLists.txt
+++ b/libs/mesh/CMakeLists.txt
@@ -22,6 +22,6 @@ target_sources(TonbMesh
 )
 
 target_link_libraries(TonbMesh
-        PUBLIC Tonb::Base Tonb::Geometry
+        PUBLIC Tonb::Base Tonb::Geometry Tonb::Numerics
 )
 

--- a/libs/numerics/CMakeLists.txt
+++ b/libs/numerics/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(TonbNumerics
         include/tonb/numerics/bisection.hxx
         include/tonb/numerics/integration.hxx
         include/tonb/numerics/newton.hxx
+        include/tonb/numerics/arc_length_integration.hxx
 )
 
 target_link_libraries(TonbNumerics

--- a/libs/numerics/include/tonb/numerics/arc_length_integration.hxx
+++ b/libs/numerics/include/tonb/numerics/arc_length_integration.hxx
@@ -1,0 +1,259 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file arc_length_integration.hxx
+ * @brief Public adaptive arc-length integration utilities for parametric planar curves.
+ *
+ * This header provides a robust and deterministic arc-length estimator for
+ * planar parametric curves when only point evaluation is available.
+ *
+ * Design intent
+ * -------------
+ * The existing scalar integration utilities in @ref integration.hxx integrate
+ * scalar-valued functions f(u). Arc length, however, is naturally expressed as:
+ *
+ *     L = integral_a^b ||C'(u)|| du
+ *
+ * which requires either:
+ * - direct derivative access, or
+ * - a reliable geometric refinement strategy when only point evaluation is
+ *   available.
+ *
+ * This module implements the second option as a public numerics API using
+ * adaptive chord refinement:
+ *
+ * - the curve is sampled at interval endpoints and midpoint,
+ * - the coarse estimate is the endpoint chord length,
+ * - the refined estimate is the sum of the two midpoint chords,
+ * - recursion continues until the local error estimate satisfies the requested
+ *   tolerance, or deterministic work limits are reached.
+ *
+ * The algorithm is robust, deterministic, and well suited for bounded curve
+ * spans used by higher-level CAD utilities such as cad2d wire length.
+ *
+ * Input convention
+ * ----------------
+ * The caller supplies a point-evaluation callable:
+ *
+ *     P = eval(u)
+ *
+ * where P is represented as std::array<real, 2>.
+ *
+ * This keeps numerics independent of any particular geometry or CAD module.
+ */
+#pragma once
+#ifndef TONB_NUMERICS_ARC_LENGTH_INTEGRATION_HXX
+#define TONB_NUMERICS_ARC_LENGTH_INTEGRATION_HXX
+
+#include <tonb/base/precision.hxx>
+#include <tonb/numerics/integration.hxx>
+
+#include <array>
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <utility>
+
+namespace tonb::numerics {
+
+    /**
+     * @brief Runtime controls for adaptive arc-length estimation.
+     *
+     * Convergence is accepted when the estimated local refinement error is less
+     * than or equal to:
+     *
+     *     max(atol, rtol * |length|)
+     *
+     * Deterministic work caps are enforced through @ref max_depth and
+     * @ref max_evals.
+     */
+    struct ArcLengthOptions {
+        /** Absolute tolerance for arc length. */
+        real atol = 1.0e-8;
+        /** Relative tolerance for arc length. */
+        real rtol = 1.0e-8;
+        /** Maximum recursive subdivision depth. */
+        int max_depth = 20;
+        /** Maximum number of point evaluations. */
+        int max_evals = 1 << 16;
+        /** Minimum accepted depth before convergence is allowed. */
+        int min_depth = 0;
+    };
+
+    /**
+     * @brief Result of adaptive arc-length estimation.
+     */
+    struct ArcLengthResult {
+        /** Estimated arc length. */
+        real value = std::numeric_limits<real>::quiet_NaN();
+        /** Accumulated error estimate. */
+        real error_est = std::numeric_limits<real>::quiet_NaN();
+        /** Number of point evaluations performed. */
+        int evals = 0;
+        /** Maximum recursion depth reached. */
+        int depth_used = 0;
+        /** True if the requested tolerance was satisfied. */
+        bool converged = false;
+        /** Termination reason. */
+        IntegrateStop reason = IntegrateStop::HitMaxEvals;
+    };
+
+    namespace detail {
+
+        inline bool arc_length_finite(const real x) noexcept {
+            return std::isfinite(x) != 0;
+        }
+
+        inline bool arc_length_finite(const std::array<real, 2>& p) noexcept {
+            return arc_length_finite(p[0]) && arc_length_finite(p[1]);
+        }
+
+        inline real arc_length_goal(const ArcLengthOptions& opt, const real approx) {
+            return std::max(opt.atol, opt.rtol * std::abs(approx));
+        }
+
+        inline real chord_length(const std::array<real, 2>& a,
+                                 const std::array<real, 2>& b) noexcept {
+            const real dx = b[0] - a[0];
+            const real dy = b[1] - a[1];
+            return std::sqrt(dx * dx + dy * dy);
+        }
+    }
+
+    /**
+     * @brief Estimate the arc length of a planar parametric curve over [a, b].
+     *
+     * @tparam Eval Callable returning std::array<real, 2> for a parameter u.
+     * @param eval Point-evaluation callable.
+     * @param a Lower parameter bound.
+     * @param b Upper parameter bound.
+     * @param opt Adaptive refinement options.
+     * @return Arc-length estimate and convergence metadata.
+     *
+     * Robustness
+     * ----------
+     * - If a == b, the result is zero and converged.
+     * - If the evaluator returns a non-finite point, the run stops with
+     *   IntegrateStop::DomainError.
+     * - If deterministic work limits are reached before convergence, the result
+     *   is returned with converged=false and the appropriate stop reason.
+     */
+    template<class Eval>
+    ArcLengthResult integrate_arc_length(Eval&& eval, const real a_in, const real b_in, ArcLengthOptions opt = {}) {
+        ArcLengthResult out{};
+
+        real a = a_in;
+        real b = b_in;
+        if (b < a) {
+            std::swap(a, b);
+        }
+
+        if (!(b > a)) {
+            out.value = 0.0;
+            out.error_est = 0.0;
+            out.converged = true;
+            out.reason = IntegrateStop::Converged;
+            return out;
+        }
+
+        struct Node {
+            real a = 0.0;
+            real b = 0.0;
+            std::array<real, 2> pa{};
+            std::array<real, 2> pm{};
+            std::array<real, 2> pb{};
+            real coarse = 0.0;
+            real tol = 0.0;
+            int depth = 0;
+        };
+
+        Node stack[64];
+        int sp = 0;
+        const int maxD = std::min(opt.max_depth, static_cast<int>(std::size(stack)) - 2);
+
+        const real m0 = std::midpoint(a, b);
+        const auto pa = eval(a);
+        const auto pm = eval(m0);
+        const auto pb = eval(b);
+        out.evals = 3;
+
+        if (!detail::arc_length_finite(pa) ||
+            !detail::arc_length_finite(pm) ||
+            !detail::arc_length_finite(pb)) {
+            out.reason = IntegrateStop::DomainError;
+            return out;
+        }
+
+        const real coarse0 = detail::chord_length(pa, pb);
+        stack[sp++] = Node{a, b, pa, pm, pb, coarse0, detail::arc_length_goal(opt, coarse0), 0};
+
+        real app_sum = 0.0;
+        real err_sum = 0.0;
+        int depth_hit = 0;
+        bool hit_max_depth = false;
+
+        while (sp > 0) {
+            Node n = stack[--sp];
+            depth_hit = std::max(depth_hit, n.depth);
+
+            const real mid = std::midpoint(n.a, n.b);
+            const real left_mid = std::midpoint(n.a, mid);
+            const real right_mid = std::midpoint(mid, n.b);
+
+            const auto plm = eval(left_mid);
+            const auto prm = eval(right_mid);
+            out.evals += 2;
+
+            if (out.evals > opt.max_evals) {
+                out.value = app_sum;
+                out.error_est = err_sum;
+                out.depth_used = depth_hit;
+                out.reason = IntegrateStop::HitMaxEvals;
+                return out;
+            }
+
+            if (!detail::arc_length_finite(plm) || !detail::arc_length_finite(prm)) {
+                out.value = app_sum;
+                out.error_est = err_sum;
+                out.depth_used = depth_hit;
+                out.reason = IntegrateStop::DomainError;
+                return out;
+            }
+
+            const real left_refined = detail::chord_length(n.pa, n.pm);
+            const real right_refined = detail::chord_length(n.pm, n.pb);
+            const real refined = left_refined + right_refined;
+            const real err = std::abs(refined - n.coarse);
+
+            const bool depth_ok = (n.depth >= opt.min_depth);
+            if (err <= n.tol && depth_ok) {
+                app_sum += refined;
+                err_sum += err;
+                continue;
+            }
+
+            if (n.depth >= maxD) {
+                app_sum += refined;
+                err_sum += err;
+                hit_max_depth = true;
+                continue;
+            }
+
+            const real child_tol = 0.5 * n.tol;
+            stack[sp++] = Node{mid, n.b, n.pm, prm, n.pb, right_refined, child_tol, n.depth + 1};
+            stack[sp++] = Node{n.a, mid, n.pa, plm, n.pm, left_refined, child_tol, n.depth + 1};
+        }
+
+        out.value = app_sum;
+        out.error_est = err_sum;
+        out.depth_used = depth_hit;
+        out.converged = (out.error_est <= detail::arc_length_goal(opt, out.value)) && !hit_max_depth;
+        out.reason = out.converged ? IntegrateStop::Converged :
+                     (hit_max_depth ? IntegrateStop::HitMaxDepth : IntegrateStop::HitMaxEvals);
+        return out;
+    }
+}
+
+#endif // TONB_NUMERICS_ARC_LENGTH_INTEGRATION_HXX

--- a/tests/cad2d/CMakeLists.txt
+++ b/tests/cad2d/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(test_cad2d_validate
         halfedge_geometry_validation_tests.cxx
         edge_builder_tests.cxx
         edge_validation_tests.cxx
+        wire_length_tests.cxx
 )
 
 target_link_libraries(test_cad2d_validate PRIVATE

--- a/tests/cad2d/wire_length_tests.cxx
+++ b/tests/cad2d/wire_length_tests.cxx
@@ -1,0 +1,83 @@
+
+/**
+ * @file wire_length_tests.cxx
+ * @brief Unit tests for cad2d wire-length utilities.
+ */
+#include <gtest/gtest.h>
+
+#include <tonb/config.hxx>
+#include <tonb/cad2d/algo/wire_length.hxx>
+#include <tonb/cad2d/tools.hxx>
+#include <tonb/cad2d/geom/curve_store.hxx>
+#include <tonb/cad2d/builder/halfedge_builder.hxx>
+#include <tonb/cad2d/builder/wire_builder.hxx>
+#include <tonb/cad2d/topo/shape.hxx>
+
+namespace tonb::cad2d::tests {
+
+TEST(Cad2dAlgo, SquareSegmentWireLengthIsFour)
+{
+#if !TONB_WITH_OCCT
+    GTEST_SKIP() << "TONB_WITH_OCCT disabled; skipping wire-length geometry tests.";
+#else
+    topo::Shape shape;
+    geom::CurveStore store;
+    build::HalfEdgeBuilder edge_builder(shape);
+    build::WireBuilder wire_builder(shape, {});
+
+    auto v0 = shape.make_vertex({0.0, 0.0});
+    auto v1 = shape.make_vertex({1.0, 0.0});
+    auto v2 = shape.make_vertex({1.0, 1.0});
+    auto v3 = shape.make_vertex({0.0, 1.0});
+
+    ASSERT_TRUE(v0);
+    ASSERT_TRUE(v1);
+    ASSERT_TRUE(v2);
+    ASSERT_TRUE(v3);
+
+    const auto c01 = cad2d::Tools::make_segment({0.0, 0.0}, {1.0, 0.0});
+    const auto c12 = cad2d::Tools::make_segment({1.0, 0.0}, {1.0, 1.0});
+    const auto c23 = cad2d::Tools::make_segment({1.0, 1.0}, {0.0, 1.0});
+    const auto c30 = cad2d::Tools::make_segment({0.0, 1.0}, {0.0, 0.0});
+
+    ASSERT_TRUE(c01.is_valid());
+    ASSERT_TRUE(c12.is_valid());
+    ASSERT_TRUE(c23.is_valid());
+    ASSERT_TRUE(c30.is_valid());
+
+    const auto r01 = c01.parameter_range();
+    const auto r12 = c12.parameter_range();
+    const auto r23 = c23.parameter_range();
+    const auto r30 = c30.parameter_range();
+
+    ASSERT_TRUE(r01.has_value());
+    ASSERT_TRUE(r12.has_value());
+    ASSERT_TRUE(r23.has_value());
+    ASSERT_TRUE(r30.has_value());
+
+    auto e01 = edge_builder.create_from_curve(store, c01, v0, v1, r01->first, r01->second, topo::Orientation::forward);
+    auto e12 = edge_builder.create_from_curve(store, c12, v1, v2, r12->first, r12->second, topo::Orientation::forward);
+    auto e23 = edge_builder.create_from_curve(store, c23, v2, v3, r23->first, r23->second, topo::Orientation::forward);
+    auto e30 = edge_builder.create_from_curve(store, c30, v3, v0, r30->first, r30->second, topo::Orientation::forward);
+
+    ASSERT_TRUE(e01) << e01.error().message;
+    ASSERT_TRUE(e12) << e12.error().message;
+    ASSERT_TRUE(e23) << e23.error().message;
+    ASSERT_TRUE(e30) << e30.error().message;
+
+    auto w = wire_builder.create({e01.value(), e12.value(), e23.value(), e30.value()});
+    ASSERT_TRUE(w) << w.error().message;
+
+    algo::WireLengthOptions options;
+    options.integration.atol = 1.0e-10;
+    options.integration.rtol = 1.0e-10;
+    options.integration.max_depth = 16;
+    options.integration.max_evals = 1 << 14; // 2 ^ 14
+
+    auto L = algo::wire_length(w.value(), store, options);
+    ASSERT_TRUE(L) << L.error().message;
+    EXPECT_NEAR(L.value(), 4.0, 1.0e-8);
+#endif
+}
+
+} // namespace tonb::cad2d::tests


### PR DESCRIPTION
…ngth integration

- add a public numerics arc-length integration API for robust and deterministic planar curve span measurement
- add `cad2d::algo::wire_length(...)` to compute geometric wire length from boundary half-edge curve spans
- resolve wire length through `geom::CurveStore` using stored `curve_id`, `u0`, and `u1`
- return explicit failures for missing curves, invalid parameters, non-finite spans, unsupported unbounded domains, and non-converged integration
- add regression coverage verifying that a square built from segment edges returns total length ≈ 4 within tolerance
- keep integration logic in `numerics` as a reusable public API rather than embedding it privately inside `cad2d`