### PR TITLE
feat(cad2d): add polygonal face-area and orientation utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.20.0] - 2026-05-07
 
 ### Highlights
 - **Geometry consistency validation completed for cad2d**: Finished the full vNext geometry-validation milestone, including vertex–curve agreement checks, curve-domain and degeneracy validation, optional shape-level geometry validation, and standardised diagnostic behaviour.
 - **Validation diagnostics strengthened**: Geometry validation now uses stable error-code mappings and consistent message prefixes, with targeted tests locking down representative diagnostic cases.
 - **Project-wide feature-config propagation introduced**: Added a generated configuration-header path so build-time feature macros such as `TONB_WITH_OCCT` can be propagated consistently through the codebase and tests.
 - **Wire geometric length utility introduced**: Added a geometry-aware wire-length algorithm in `cad2d/algo`, backed by a public robust arc-length integration API in `numerics`.
+- **Polygonal face area and orientation utilities introduced**: Added the first face-level geometric utilities in `cad2d/algo`, including signed area, loop orientation classification, and standard face-orientation helpers for segment-only polygonal faces.
 
 ### Added
 - **Geometry-aware half-edge validation**:
@@ -37,6 +38,15 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - explicit failure reporting for missing curves, invalid parameters, non-finite spans, and unsupported unbounded domains
 - **Wire-length test coverage**:
     - regression test verifying that a square built from segment edges returns a total length of approximately 4 within tolerance
+- **Polygonal face area and orientation utilities in `cad2d/algo`**:
+    - signed polygonal area computation for wires and faces using segment-only geometric spans
+    - loop orientation classification based on signed-area sign
+    - face-level orientation checks using the documented convention of outer CCW and holes CW
+    - face-orientation normalisation helpers based on reversing wires through existing twin half-edges
+    - explicit rejection of non-linear spans for the current polygon-only milestone scope
+- **Face-area test coverage**:
+    - regression test verifying that a unit square face returns signed area ≈ 1
+    - regression test verifying that a hole subtracts correctly from the outer face area
 
 ### Changed
 - **cad2d validation flow**:
@@ -51,11 +61,13 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - robust arc-length integration is now exposed from `numerics` as a public reusable API rather than being embedded privately inside `cad2d`
 - **cad2d algorithm layering**:
     - wire-length computation is implemented as an algorithm-layer consumer of topology, geometry storage, and public numerics utilities
+    - polygonal face-area computation is implemented as an algorithm-layer consumer of topology, geometry storage, and existing orientation conventions
 
 ### Notes
 - This completes **Milestone vNext — Geometry Consistency Validation (Option B)**.
 - This also completes **Milestone vNext+2 — Wire Geometry Utilities**, introducing the first wire-level geometric utility.
-- The next planned milestone is **vNext+3 — Face Geometry Basics**, beginning with signed-area and orientation utilities.
+- This also completes **Milestone vNext+3 — Face Geometry Basics**, introducing signed-area and orientation utilities for segment-only polygonal faces.
+- The next planned milestone is **vNext+4 — Curve Intersections Foundation**.
 
 ## [0.19.0] - 2025-08-21
 ### Highlights

--- a/docs/milestones/cad2d_autocad_like_development_roadmap.md
+++ b/docs/milestones/cad2d_autocad_like_development_roadmap.md
@@ -1,0 +1,693 @@
+# cad2d Roadmap: Next Milestones Toward an AutoCAD-like 2D CAD Core
+
+## Purpose
+
+This roadmap defines the next practical development steps for `cad2d` after the completion of:
+
+- topology foundation
+- geometry-aware validation
+- wire geometric length
+- polygonal face signed area and orientation utilities
+
+The long-term goal is to move toward a 2D CAD core with capabilities similar in spirit to AutoCAD for sketching and region construction, while preserving the current disciplined architecture:
+
+- `topo`: topology ownership and invariants
+- `build`: controlled construction and mutation helpers
+- `validate`: explicit correctness checks
+- `geom`: geometry storage and evaluation
+- `algo`: higher-level geometric/topological algorithms
+- `numerics`: reusable numerical building blocks
+
+This roadmap is intentionally staged so that later high-level editing and boolean tools are built on robust geometric decomposition primitives rather than ad hoc special cases.
+
+---
+
+# Milestone: vNext+4 --- Curve Intersections Foundation
+
+## Goal
+
+Introduce a robust and explicit intersection layer for 2D curve spans. This milestone provides the geometric basis for trimming, splitting, fragmentation, region extraction, and eventually boolean operations.
+
+---
+
+## Issue 8 --- Public 2D Intersection Result Types
+
+**Priority:** High  
+**Domain:** cad2d/geom  
+**Type:** Feature / Foundation
+
+### Description
+
+Define public result types for 2D curve-curve intersection queries.
+
+These types should represent:
+
+- isolated point intersections
+- overlap / coincident intervals
+- tangent intersections where relevant
+- failure / unsupported cases with explicit diagnostics
+
+The API should remain kernel-agnostic at the `cad2d` surface even if internally backed by OCCT.
+
+### Acceptance Criteria
+
+- Public intersection result types exist with full documentation.
+- Result model distinguishes point intersections from overlapping spans.
+- Results include parameters on both input curves.
+- Diagnostics are explicit and stable.
+
+### Tests
+
+- line-line crossing returns one point with parameters on both curves
+- disjoint line-line returns no intersections
+- coincident overlapping segments produce overlap result rather than ambiguous point set
+
+---
+
+## Issue 9 --- Segment-First Curve-Curve Intersection API
+
+**Priority:** High  
+**Domain:** cad2d/geom  
+**Type:** Feature
+
+### Description
+
+Implement an initial intersection API for bounded curve spans, starting with segment-first support.
+
+Recommended initial support:
+
+- segment-segment
+- segment-arc
+- arc-arc
+
+General curve support can be added later without changing the public result model.
+
+### Acceptance Criteria
+
+- Bounded span intersection API exists.
+- Segment-segment is robust and deterministic.
+- Returned parameters are consistent with span direction.
+- Unsupported combinations fail explicitly via `Result`.
+
+### Tests
+
+- orthogonal segments intersect correctly
+- non-overlapping collinear segments return no point intersection
+- segment-arc and arc-arc representative cases pass
+
+---
+
+## Issue 10 --- HalfEdge Span Intersection Utility
+
+**Priority:** High  
+**Domain:** cad2d/algo  
+**Type:** Feature / Integration
+
+### Description
+
+Add a utility that intersects two topology half-edge spans by resolving their curves from `CurveStore` and calling the geometry intersection API.
+
+This should bridge topology and geometry cleanly without embedding topology assumptions into `geom`.
+
+### Acceptance Criteria
+
+- Takes two half-edges and a `CurveStore`
+- Returns intersection results in edge/span terms
+- Rejects invalid or missing curve bindings
+- Deterministic output ordering
+
+### Tests
+
+- crossing half-edges return correct intersection
+- invalid curve id fails cleanly
+- same geometry with disjoint parameter spans returns no intersection
+
+---
+
+# Milestone: vNext+5 --- Edge and Wire Fragmentation
+
+## Goal
+
+Make it possible to split topology entities at geometric parameters and build fragment-level representations. This is the minimum required substrate for trim, break, and booleans.
+
+---
+
+## Issue 11 --- Edge Split Operation
+
+**Priority:** High  
+**Domain:** cad2d/topo + build  
+**Type:** Feature / Controlled Refactor
+
+### Description
+
+Introduce a controlled split operation for a first-class `topo::Edge` at a parameter value.
+
+The operation should:
+
+- create a new vertex at the split point
+- split both half-edges consistently
+- preserve edge ownership and twin invariants
+- keep curve bindings consistent
+
+### Acceptance Criteria
+
+- Splitting one edge yields two valid edges
+- Twin and owner invariants remain valid
+- New parameter spans are consistent and non-degenerate
+
+### Tests
+
+- segment edge split at midpoint yields two valid child edges
+- splitting near an endpoint is rejected by tolerance rules
+- edge validation passes for both resulting edges
+
+---
+
+## Issue 12 --- Wire Split and Fragment Extraction
+
+**Priority:** High  
+**Domain:** cad2d/algo + build  
+**Type:** Feature
+
+### Description
+
+Build utilities for splitting a wire at one or more edge parameters and extracting fragment sequences.
+
+This milestone should support:
+
+- ordered split points per edge
+- fragment half-edge sequences
+- deterministic fragment ordering
+
+### Acceptance Criteria
+
+- Wire can be fragmented at one or more geometric split locations
+- Fragment ordering is deterministic
+- Boundary continuity is preserved within each fragment
+
+### Tests
+
+- splitting a rectangular wire at one edge yields expected fragment counts
+- multiple splits on one edge are handled in sorted parameter order
+- invalid split requests fail explicitly
+
+---
+
+## Issue 13 --- Planar Arrangement Fragment Graph
+
+**Priority:** Medium  
+**Domain:** cad2d/algo  
+**Type:** Feature / Foundation
+
+### Description
+
+Construct a fragment graph from intersecting edges/wires.
+
+This graph should represent:
+
+- fragment vertices
+- directed fragment edges
+- adjacency and incidence needed for loop extraction
+
+This is the topological decomposition layer booleans will later depend on.
+
+### Acceptance Criteria
+
+- Graph can be built deterministically from fragmented inputs
+- Connectivity is explicit and documented
+- Debug/inspection utilities exist for testing
+
+### Tests
+
+- two intersecting rectangles produce expected fragment graph topology
+- graph connectivity is stable across repeated runs
+
+---
+
+# Milestone: vNext+6 --- Sketch Region Construction
+
+## Goal
+
+Build region extraction from fragmented sketches so closed loops and faces can be created automatically from intersecting input geometry.
+
+---
+
+## Issue 14 --- Loop Extraction from Fragment Graph
+
+**Priority:** High  
+**Domain:** cad2d/algo  
+**Type:** Feature
+
+### Description
+
+Extract closed loops from the planar fragment graph.
+
+The extractor should identify bounded cycles and produce them in a deterministic order suitable for later face construction.
+
+### Acceptance Criteria
+
+- Closed loops can be extracted from fragmented planar arrangements
+- Loop orientation is classified deterministically
+- Duplicate/redundant loops are filtered consistently
+
+### Tests
+
+- intersecting rectangles yield expected bounded loops
+- simple single rectangle yields one loop
+- open sketches yield no closed loop result
+
+---
+
+## Issue 15 --- Face Construction from Sketch Regions
+
+**Priority:** High  
+**Domain:** cad2d/build + algo  
+**Type:** Feature / Integration
+
+### Description
+
+Create faces automatically from extracted loops.
+
+This should classify:
+
+- outer loops
+- hole loops
+
+using the signed-area/orientation utilities already added earlier.
+
+### Acceptance Criteria
+
+- Valid faces can be built from loop sets
+- Hole assignment is correct for nested regions
+- Face orientation can be normalised to standard convention
+
+### Tests
+
+- single rectangle sketch becomes one face
+- nested loops become outer face plus hole
+- invalid ambiguous nesting fails explicitly
+
+---
+
+## Issue 16 --- Region Validation Utilities
+
+**Priority:** Medium  
+**Domain:** cad2d/validate + algo  
+**Type:** Feature
+
+### Description
+
+Add validation helpers for sketch-derived regions and loop sets before final face construction.
+
+### Acceptance Criteria
+
+- Region diagnostics are explicit
+- Invalid nesting or inconsistent orientation is detected
+- Validation is deterministic
+
+### Tests
+
+- invalid hole nesting is caught
+- duplicate loops are rejected
+- ambiguous region assignment fails cleanly
+
+---
+
+# Milestone: vNext+7 --- Sketch Editing Operations
+
+## Goal
+
+Introduce user-facing CAD editing operations on top of the new intersection and fragmentation foundations.
+
+---
+
+## Issue 17 --- Trim Operation
+
+**Priority:** High  
+**Domain:** cad2d/algo  
+**Type:** Feature
+
+### Description
+
+Add a trim operation for bounded curve/edge spans based on intersection and splitting results.
+
+### Acceptance Criteria
+
+- Can trim a span against another selected boundary
+- Resulting topology is valid
+- Builder/validator integration remains explicit
+
+### Tests
+
+- trim a segment against another crossing segment
+- trimming outside valid span fails
+- resulting edge set validates
+
+---
+
+## Issue 18 --- Break / Split-at-Point Operation
+
+**Priority:** High  
+**Domain:** cad2d/algo + build  
+**Type:** Feature
+
+### Description
+
+Expose a user-level operation that breaks a curve/edge/wire at a specified point or parameter.
+
+### Acceptance Criteria
+
+- Produces valid fragments
+- Works with deterministic tolerance rules
+- Reuses underlying edge split functionality
+
+### Tests
+
+- break segment at midpoint yields two fragments
+- break at endpoint is rejected or no-op by rule
+- resulting topology validates
+
+---
+
+## Issue 19 --- Join / Coalesce Operation
+
+**Priority:** Medium  
+**Domain:** cad2d/algo  
+**Type:** Feature
+
+### Description
+
+Join collinear/compatible neighbouring spans into larger spans when geometrically and topologically legal.
+
+### Acceptance Criteria
+
+- Compatible segment fragments can be merged
+- Invalid joins are rejected
+- Resulting topology remains valid
+
+### Tests
+
+- adjacent collinear segments join successfully
+- angular mismatch prevents join
+- merged result validates
+
+---
+
+# Milestone: vNext+8 --- 2D Boolean Operators
+
+## Goal
+
+Introduce robust 2D region booleans after the arrangement and region-construction foundations are in place.
+
+---
+
+## Issue 20 --- Face Boolean Classification Rules
+
+**Priority:** High  
+**Domain:** cad2d/algo  
+**Type:** Feature / Foundation
+
+### Description
+
+Define and implement inside/outside classification rules for fragmented regions under:
+
+- union
+- intersection
+- subtraction
+
+### Acceptance Criteria
+
+- Classification is deterministic
+- Rules are documented clearly
+- Works on polygonal baseline first
+
+### Tests
+
+- rectangle union classification correct
+- rectangle subtraction classification correct
+- rectangle intersection classification correct
+
+---
+
+## Issue 21 --- Polygonal Boolean Operators
+
+**Priority:** High  
+**Domain:** cad2d/algo + build  
+**Type:** Feature
+
+### Description
+
+Implement boolean operations for polygonal faces using the region-construction pipeline.
+
+### Acceptance Criteria
+
+- Union works for overlapping rectangles
+- Intersection works for overlapping rectangles
+- Subtraction works for hole-producing cases
+- Resulting faces validate and orient correctly
+
+### Tests
+
+- overlapping rectangles union/intersection/subtraction pass
+- subtraction can create hole when appropriate
+- disjoint cases behave predictably
+
+---
+
+## Issue 22 --- Boolean Result Reconstruction
+
+**Priority:** Medium  
+**Domain:** cad2d/build + algo  
+**Type:** Feature
+
+### Description
+
+Reconstruct final face topology from classified result regions, preserving standard orientation conventions and explicit diagnostics.
+
+### Acceptance Criteria
+
+- Result faces are valid cad2d faces
+- Outer/hole relationships are reconstructed correctly
+- Validation passes on boolean outputs
+
+### Tests
+
+- boolean results validate structurally and geometrically
+- multiple-region outputs are handled deterministically
+
+---
+
+# Milestone: vNext+9 --- Drafting and Convenience Geometry
+
+## Goal
+
+Add high-value drafting operations expected from a practical 2D CAD system.
+
+---
+
+## Issue 23 --- Offset Curves / Offset Wires
+
+**Priority:** Medium  
+**Domain:** cad2d/algo + geom  
+**Type:** Feature
+
+### Description
+
+Generate offsets for segment-first and arc-first geometries with explicit failure paths for unsupported or unstable cases.
+
+### Acceptance Criteria
+
+- segment wire offsets work reliably
+- corner handling is documented
+- invalid self-intersection cases fail explicitly or produce diagnostic output
+
+### Tests
+
+- rectangle offset outward and inward
+- invalid offset on too-small feature fails cleanly
+
+---
+
+## Issue 24 --- Fillet Operation
+
+**Priority:** Medium  
+**Domain:** cad2d/algo + build  
+**Type:** Feature
+
+### Description
+
+Insert tangent arc fillets between compatible segment pairs.
+
+### Acceptance Criteria
+
+- creates valid tangent connection
+- trims/extends adjacent spans as needed
+- resulting topology validates
+
+### Tests
+
+- right-angle segment pair fillet succeeds
+- impossible radius fails explicitly
+
+---
+
+## Issue 25 --- Chamfer Operation
+
+**Priority:** Medium  
+**Domain:** cad2d/algo + build  
+**Type:** Feature
+
+### Description
+
+Insert chamfer spans between compatible segment pairs.
+
+### Acceptance Criteria
+
+- valid chamfer span created
+- adjacent spans updated consistently
+- result validates
+
+### Tests
+
+- simple corner chamfer succeeds
+- oversized chamfer fails explicitly
+
+---
+
+# Milestone: vNext+10 --- User-Level CAD Workflows
+
+## Goal
+
+Move from low-level primitives toward the workflows expected from a practical sketching/CAD environment.
+
+---
+
+## Issue 26 --- Region Creation from User Sketches
+
+**Priority:** High  
+**Domain:** cad2d/algo + build  
+**Type:** Feature / Workflow
+
+### Description
+
+Given an arbitrary user sketch set, detect valid closed regions and create faces automatically.
+
+### Acceptance Criteria
+
+- simple sketch collections produce faces automatically
+- ambiguous/open sketches return clear diagnostics
+- deterministic results
+
+### Tests
+
+- sketch with one rectangle produces one face
+- sketch with nested loops produces hole
+- open sketch produces no face
+
+---
+
+## Issue 27 --- Constraint-Friendly Topology Utilities
+
+**Priority:** Medium  
+**Domain:** cad2d/topo + algo  
+**Type:** Feature / Future-proofing
+
+### Description
+
+Prepare topology utilities that will later support sketch constraints and parametric editing, without implementing a full solver yet.
+
+### Acceptance Criteria
+
+- stable references for editable spans are documented
+- split/join/edit operations preserve usable identity where possible
+- diagnostics for invalidated references are explicit
+
+### Tests
+
+- editing operations preserve expected identity rules
+- invalidated references are detectable
+
+---
+
+## Issue 28 --- DXF-Oriented Sketch Export/Import Foundation
+
+**Priority:** Medium  
+**Domain:** cad2d/io + geom  
+**Type:** Feature
+
+### Description
+
+Lay the foundation for importing/exporting practical 2D CAD sketches in a DXF-oriented way.
+
+### Acceptance Criteria
+
+- minimal line/arc export exists
+- import/export mapping rules are documented
+- geometry/topology reconstruction path is clear
+
+### Tests
+
+- exported simple sketch round-trips structurally
+- unsupported entities fail explicitly
+
+---
+
+# Recommended Order of Execution
+
+The recommended implementation order is:
+
+1. **vNext+4** — intersections foundation  
+2. **vNext+5** — edge and wire fragmentation  
+3. **vNext+6** — sketch region construction  
+4. **vNext+7** — editing operations  
+5. **vNext+8** — polygonal booleans  
+6. **vNext+9** — drafting operations  
+7. **vNext+10** — workflow and exchange foundations  
+
+This order is intentional:
+
+- booleans should not be attempted before fragmentation and region extraction
+- trim/break/join become much easier once splitting infrastructure exists
+- drafting operations such as offset/fillet/chamfer are more reliable once the arrangement/editing pipeline is mature
+
+---
+
+# Strategic Notes
+
+## Why not start with booleans immediately?
+
+Boolean operators depend on a large amount of prior machinery:
+
+- curve intersections
+- robust splitting
+- fragment graph construction
+- loop extraction
+- region classification
+- face reconstruction
+
+Attempting booleans before those pieces typically leads to brittle special-case code that must later be rewritten.
+
+## What is realistically achievable?
+
+An AutoCAD-like **2D CAD core** is realistically achievable if the project stays disciplined and incremental.
+
+The practical target should be:
+
+- robust 2D topology and geometry core
+- sketch-to-region workflow
+- editing operations
+- polygonal and later curved booleans
+- drafting-style operations
+- file exchange foundations
+
+This is a strong and realistic long-term direction for `cad2d`.
+
+---
+
+# Immediate Recommendation
+
+The next actual implementation milestone should be:
+
+## **Milestone: vNext+4 --- Curve Intersections Foundation**
+
+That milestone unlocks everything that follows and is the correct next step after the current state of the library.

--- a/libs/cad2d/CMakeLists.txt
+++ b/libs/cad2d/CMakeLists.txt
@@ -70,6 +70,7 @@ target_sources(TonbCAD2d
         src/geom/curve_store.cxx
         src/geom/curve_ops.cxx
         src/algo/wire_length.cxx
+        src/algo/face_area.cxx
         PUBLIC
         FILE_SET HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -110,6 +111,7 @@ target_sources(TonbCAD2d
         include/tonb/cad2d/geom/curve_store.hxx
         include/tonb/cad2d/geom/curve_ops.hxx
         include/tonb/cad2d/algo/wire_length.hxx
+        include/tonb/cad2d/algo/face_area.hxx
 )
 
 # Backend-specific sources

--- a/libs/cad2d/include/tonb/cad2d/algo/face_area.hxx
+++ b/libs/cad2d/include/tonb/cad2d/algo/face_area.hxx
@@ -1,0 +1,217 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file face_area.hxx
+ * @brief Declares polygonal face-area and orientation utilities for cad2d.
+ *
+ * This module provides the first face-level geometric utilities for cad2d.
+ * The current implementation is intentionally limited to polygonal boundaries
+ * represented by segment-like half-edge spans. General curved-area integration
+ * is outside the scope of this issue and must be added separately in a future
+ * milestone.
+ *
+ * Scope of this module
+ * --------------------
+ * - compute signed area of a wire interpreted as a polygon boundary
+ * - classify wire orientation from the sign of the signed area
+ * - compute signed area of a face as outer-loop area plus hole-loop areas
+ * - detect whether a face matches the documented orientation convention
+ * - optionally normalise wire and face orientation using existing twin
+ *   half-edges
+ *
+ * Orientation convention
+ * ----------------------
+ * This module documents and uses the following standard convention:
+ *
+ * - outer boundary : counter-clockwise (CCW)
+ * - hole boundaries: clockwise (CW)
+ *
+ * Under that convention:
+ * - a CCW loop has positive signed area
+ * - a CW loop has negative signed area
+ * - a properly oriented face has positive total area
+ *
+ * Important restriction
+ * ---------------------
+ * The algorithms in this file are designed for segment-only polygonal loops.
+ * To keep the implementation honest, the default behaviour checks that each
+ * half-edge span behaves like a straight segment within a configurable
+ * tolerance. If a span is curved, the utility fails explicitly instead of
+ * silently approximating it as polygonal.
+ */
+#pragma once
+#ifndef TONB_CAD2D_ALGO_FACE_AREA_HXX
+#define TONB_CAD2D_ALGO_FACE_AREA_HXX
+
+#include <tonb/cad2d/module.hxx>
+#include <tonb/cad2d/topo/result.hxx>
+#include <tonb/base/precision.hxx>
+
+#include <memory>
+
+namespace tonb::cad2d::topo {
+    class Wire;
+    class Face;
+}
+
+namespace tonb::cad2d::geom {
+    class CurveStore;
+}
+
+namespace tonb::cad2d::algo {
+
+    /**
+     * @brief Orientation classification for polygon loops.
+     */
+    enum class LoopOrientation : std::uint8_t {
+        collinear = 0,  ///< Area magnitude is below the configured epsilon.
+        ccw,            ///< Positive signed area.
+        cw              ///< Negative signed area.
+    };
+
+    /**
+     * @brief Options controlling polygon-area and orientation utilities.
+     */
+    struct FaceAreaOptions {
+        /**
+         * @brief Area epsilon used to classify nearly-zero signed areas.
+         */
+        real area_epsilon = 1.0e-12;
+
+        /**
+         * @brief Tolerance used to decide whether a half-edge span behaves like
+         *        a straight segment.
+         *
+         * The current implementation samples the midpoint of the referenced
+         * curve span and compares it against the chord midpoint. If the
+         * deviation exceeds this tolerance, the edge is rejected as non-linear.
+         */
+        real linearity_tolerance = 1.0e-9;
+
+        /**
+         * @brief If true, reject non-linear edge spans.
+         *
+         * This should remain true for the current milestone because only
+         * segment-only polygonal faces are supported.
+         */
+        bool require_linear_geometry = true;
+
+        /**
+         * @brief If true, update next/prev links when a wire is normalised.
+         */
+        bool update_next_prev_on_normalize = true;
+    };
+
+    /**
+     * @brief Compute the signed area of a wire interpreted as a polygon loop.
+     *
+     * The wire must be closed and continuous, and each boundary half-edge must
+     * resolve to a segment-like geometric span.
+     *
+     * @param wire Boundary wire to evaluate.
+     * @param curves Curve registry used to resolve curve ids.
+     * @param options Polygon-area options and tolerances.
+     * @return Signed area on success.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<real> signed_area_of_wire_polygon(
+        const std::shared_ptr<topo::Wire>& wire,
+        const geom::CurveStore& curves,
+        const FaceAreaOptions& options = {});
+
+    /**
+     * @brief Classify wire orientation from its signed polygon area.
+     *
+     * @param wire Boundary wire to classify.
+     * @param curves Curve registry used to resolve curve ids.
+     * @param options Polygon-area options and tolerances.
+     * @return Loop orientation classification on success.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<LoopOrientation> classify_wire_orientation(
+        const std::shared_ptr<topo::Wire>& wire,
+        const geom::CurveStore& curves,
+        const FaceAreaOptions& options = {});
+
+    /**
+     * @brief Compute the signed area of a polygonal face.
+     *
+     * The returned value is:
+     *
+     *     A_face = A_outer + sum(A_hole_i)
+     *
+     * so a face that follows the documented convention (outer CCW, holes CW)
+     * yields a positive total area equal to outer minus holes.
+     *
+     * @param face Face to evaluate.
+     * @param curves Curve registry used to resolve curve ids.
+     * @param options Polygon-area options and tolerances.
+     * @return Signed face area on success.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<real> signed_area_of_face_polygon(
+        const std::shared_ptr<topo::Face>& face,
+        const geom::CurveStore& curves,
+        const FaceAreaOptions& options = {});
+
+    /**
+     * @brief Check whether a face matches the standard orientation convention.
+     *
+     * Standard convention:
+     * - outer boundary is CCW
+     * - hole boundaries are CW
+     *
+     * @param face Face to inspect.
+     * @param curves Curve registry used to resolve curve ids.
+     * @param options Polygon-area options and tolerances.
+     * @return True on success if the face already matches the convention.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<bool> face_has_standard_orientation(
+        const std::shared_ptr<topo::Face>& face,
+        const geom::CurveStore& curves,
+        const FaceAreaOptions& options = {});
+
+    /**
+     * @brief Reverse a wire by replacing its boundary with the reversed twin sequence.
+     *
+     * This function requires that every boundary half-edge has a valid twin.
+     * The wire boundary is rewritten as:
+     *
+     *     [e0, e1, ..., en-1] -> [twin(en-1), ..., twin(e1), twin(e0)]
+     *
+     * Optionally, the next/prev links of the new sequence are updated to match
+     * the new boundary order.
+     *
+     * This utility intentionally changes only the wire boundary ordering and the
+     * optional next/prev links. It does not update face assignment or any other
+     * higher-level topology relationships.
+     *
+     * @param wire Wire to reverse.
+     * @param options Polygon-area options and normalize behaviour.
+     * @return True if the wire was changed, false if it was already degenerate.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<bool> reverse_wire_using_twins(
+        const std::shared_ptr<topo::Wire>& wire,
+        const FaceAreaOptions& options = {});
+
+    /**
+     * @brief Normalise a face to the standard orientation convention.
+     *
+     * Standard convention:
+     * - outer boundary is CCW
+     * - hole boundaries are CW
+     *
+     * Wires are reversed only when necessary. Reversal is performed using
+     * existing twin half-edges, so each affected wire must be reversible
+     * through valid twin links.
+     *
+     * @param face Face to normalise.
+     * @param curves Curve registry used to resolve curve ids.
+     * @param options Polygon-area options and normalize behaviour.
+     * @return True if any wire was modified.
+     */
+    TNBCAD2D_ND_EXPORT topo::Result<bool> normalize_face_polygon_orientations(
+        const std::shared_ptr<topo::Face>& face,
+        const geom::CurveStore& curves,
+        const FaceAreaOptions& options = {});
+}
+
+#endif // TONB_CAD2D_ALGO_FACE_AREA_HXX

--- a/libs/cad2d/src/algo/face_area.cxx
+++ b/libs/cad2d/src/algo/face_area.cxx
@@ -1,0 +1,483 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file face_area.cxx
+ * @brief Implements polygonal face-area and orientation utilities for cad2d.
+ */
+#include <tonb/cad2d/algo/face_area.hxx>
+
+#include <tonb/cad2d/topo/face.hxx>
+#include <tonb/cad2d/topo/wire.hxx>
+#include <tonb/cad2d/topo/halfedge.hxx>
+#include <tonb/cad2d/geom/curve_store.hxx>
+#include <tonb/cad2d/geom/curve_ops.hxx>
+#include <tonb/cad2d/point.hxx>
+
+#include <cmath>
+#include <sstream>
+#include <vector>
+
+namespace tonb::cad2d::algo {
+    namespace {
+
+        struct XY {
+            real x = 0.0;
+            real y = 0.0;
+        };
+
+        std::string wire_ctx(const std::shared_ptr<topo::Wire>& wire) {
+            if (!wire) {
+                return "FaceArea";
+            }
+            return "FaceArea (wire id=" + std::to_string(wire->id()) + ")";
+        }
+
+        std::string face_ctx(const std::shared_ptr<topo::Face>& face) {
+            if (!face) {
+                return "FaceArea";
+            }
+            return "FaceArea (face id=" + std::to_string(face->id()) + ")";
+        }
+
+        bool finite(const real x) noexcept {
+            return std::isfinite(x) != 0;
+        }
+
+        XY to_xy(const Point& p) {
+            return XY{p.x(), p.y()};
+        }
+
+        real cross(const XY& a, const XY& b) noexcept {
+            return a.x * b.y - a.y * b.x;
+        }
+
+        real norm(const XY& v) noexcept {
+            return std::sqrt(v.x * v.x + v.y * v.y);
+        }
+
+        real distance(const XY& a, const XY& b) noexcept {
+            return norm(XY{b.x - a.x, b.y - a.y});
+        }
+
+        XY midpoint(const XY& a, const XY& b) noexcept {
+            return XY{0.5 * (a.x + b.x), 0.5 * (a.y + b.y)};
+        }
+
+        topo::Result<void> ensure_segment_like_span(const std::shared_ptr<topo::HalfEdge>& edge,
+                                                    const Curve& curve,
+                                                    const FaceAreaOptions& options) {
+            if (!options.require_linear_geometry) {
+                return {};
+            }
+
+            const real u0 = edge->u0();
+            const real u1 = edge->u1();
+            const real um = 0.5 * (u0 + u1);
+
+            const XY p0 = to_xy(geom::value(curve, u0));
+            const XY p1 = to_xy(geom::value(curve, u1));
+            const XY pm = to_xy(geom::value(curve, um));
+            const XY chord_mid = midpoint(p0, p1);
+
+            const real dev = distance(pm, chord_mid);
+            if (dev > options.linearity_tolerance) {
+                std::ostringstream oss;
+                oss << "FaceArea: half-edge id=" << edge->id()
+                    << " is not segment-like within tolerance"
+                    << " (midpoint deviation=" << dev
+                    << ", tolerance=" << options.linearity_tolerance << ")";
+                return topo::Result<void>(topo::ResultError{
+                    oss.str(),
+                    topo::ErrorCode::geometry_error
+                });
+            }
+
+            return {};
+        }
+
+        topo::Result<std::pair<XY, XY>> directed_edge_points(const std::shared_ptr<topo::HalfEdge>& edge,
+                                                             const geom::CurveStore& curves,
+                                                             const FaceAreaOptions& options) {
+            if (!edge) {
+                return topo::Result<std::pair<XY, XY>>(topo::ResultError{
+                    "FaceArea: wire contains a null or expired half-edge",
+                    topo::ErrorCode::topology_error
+                });
+            }
+
+            const auto cid = edge->curve_id();
+            if (cid == 0) {
+                return topo::Result<std::pair<XY, XY>>(topo::ResultError{
+                    "FaceArea: half-edge stores invalid curve id 0",
+                    topo::ErrorCode::geometry_error
+                });
+            }
+
+            if (!curves.contains(cid)) {
+                return topo::Result<std::pair<XY, XY>>(topo::ResultError{
+                    "FaceArea: referenced curve id is not present in CurveStore",
+                    topo::ErrorCode::geometry_error
+                });
+            }
+
+            const auto& curve = curves.get(cid);
+
+            const real u0 = edge->u0();
+            const real u1 = edge->u1();
+            if (!finite(u0) || !finite(u1)) {
+                return topo::Result<std::pair<XY, XY>>(topo::ResultError{
+                    "FaceArea: half-edge parameters are not finite",
+                    topo::ErrorCode::geometry_error
+                });
+            }
+
+            if (const auto linear = ensure_segment_like_span(edge, curve, options); !linear) {
+                return topo::Result<std::pair<XY, XY>>(linear.error());
+            }
+
+            return topo::Result<std::pair<XY, XY>>(
+                std::make_pair(to_xy(geom::value(curve, u0)), to_xy(geom::value(curve, u1))));
+        }
+
+        topo::Result<real> wire_area_impl(const std::shared_ptr<topo::Wire>& wire,
+                                          const geom::CurveStore& curves,
+                                          const FaceAreaOptions& options) {
+            if (!wire) {
+                return topo::Result<real>(topo::ResultError{
+                    "FaceArea: wire pointer is null",
+                    topo::ErrorCode::invalid_input
+                });
+            }
+
+            if (wire->empty()) {
+                return topo::Result<real>(topo::ResultError{
+                    wire_ctx(wire) + ": wire boundary is empty",
+                    topo::ErrorCode::invalid_input
+                });
+            }
+
+            const auto edges = wire->edges_locked();
+            XY first_start{};
+            XY prev_end{};
+            bool have_first = false;
+            real twice_area = 0.0;
+
+            for (std::size_t i = 0; i < edges.size(); ++i) {
+                const auto re = directed_edge_points(edges[i], curves, options);
+                if (!re) {
+                    return topo::Result<real>(topo::ResultError{
+                        wire_ctx(wire) + ": failed on boundary edge index " + std::to_string(i) +
+                        " (" + re.error().message + ")",
+                        re.error().code
+                    });
+                }
+
+                const XY p0 = re.value().first;
+                const XY p1 = re.value().second;
+
+                if (!have_first) {
+                    first_start = p0;
+                    have_first = true;
+                } else {
+                    if (distance(prev_end, p0) > options.linearity_tolerance) {
+                        std::ostringstream oss;
+                        oss << wire_ctx(wire)
+                            << ": wire is not continuous in geometric traversal order"
+                            << " (edge index=" << i
+                            << ", gap=" << distance(prev_end, p0)
+                            << ", tolerance=" << options.linearity_tolerance << ")";
+                        return topo::Result<real>(topo::ResultError{
+                            oss.str(),
+                            topo::ErrorCode::validation_failed
+                        });
+                    }
+                }
+
+                twice_area += cross(p0, p1);
+                prev_end = p1;
+            }
+
+            if (distance(prev_end, first_start) > options.linearity_tolerance) {
+                std::ostringstream oss;
+                oss << wire_ctx(wire)
+                    << ": wire is not geometrically closed"
+                    << " (closure gap=" << distance(prev_end, first_start)
+                    << ", tolerance=" << options.linearity_tolerance << ")";
+                return topo::Result<real>(topo::ResultError{
+                    oss.str(),
+                    topo::ErrorCode::validation_failed
+                });
+            }
+
+            return topo::Result<real>(0.5 * twice_area);
+        }
+
+        topo::Result<bool> normalize_wire_if_needed(const std::shared_ptr<topo::Wire>& wire,
+                                                    const LoopOrientation expected,
+                                                    const geom::CurveStore& curves,
+                                                    const FaceAreaOptions& options) {
+            const auto rc = classify_wire_orientation(wire, curves, options);
+            if (!rc) {
+                return topo::Result<bool>(rc.error());
+            }
+
+            const auto current = rc.value();
+            if (current == LoopOrientation::collinear) {
+                return topo::Result<bool>(topo::ResultError{
+                    wire_ctx(wire) + ": cannot normalize a collinear or zero-area loop",
+                    topo::ErrorCode::degenerate
+                });
+            }
+
+            if (current == expected) {
+                return topo::Result<bool>(false);
+            }
+
+            return reverse_wire_using_twins(wire, options);
+        }
+    }
+
+    topo::Result<real> signed_area_of_wire_polygon(const std::shared_ptr<topo::Wire>& wire,
+                                                   const geom::CurveStore& curves,
+                                                   const FaceAreaOptions& options) {
+        return wire_area_impl(wire, curves, options);
+    }
+
+    topo::Result<LoopOrientation> classify_wire_orientation(const std::shared_ptr<topo::Wire>& wire,
+                                                            const geom::CurveStore& curves,
+                                                            const FaceAreaOptions& options) {
+        const auto ra = wire_area_impl(wire, curves, options);
+        if (!ra) {
+            return topo::Result<LoopOrientation>(ra.error());
+        }
+
+        const real a = ra.value();
+        if (std::abs(a) <= options.area_epsilon) {
+            return topo::Result<LoopOrientation>(LoopOrientation::collinear);
+        }
+
+        return topo::Result<LoopOrientation>(a > 0.0 ? LoopOrientation::ccw : LoopOrientation::cw);
+    }
+
+    topo::Result<real> signed_area_of_face_polygon(const std::shared_ptr<topo::Face>& face,
+                                                   const geom::CurveStore& curves,
+                                                   const FaceAreaOptions& options) {
+        if (!face) {
+            return topo::Result<real>(topo::ResultError{
+                "FaceArea: face pointer is null",
+                topo::ErrorCode::invalid_input
+            });
+        }
+
+        const auto outer = face->outer();
+        if (!outer) {
+            return topo::Result<real>(topo::ResultError{
+                face_ctx(face) + ": outer wire is null or expired",
+                topo::ErrorCode::topology_error
+            });
+        }
+
+        real total = 0.0;
+
+        const auto ro = signed_area_of_wire_polygon(outer, curves, options);
+        if (!ro) {
+            return topo::Result<real>(topo::ResultError{
+                face_ctx(face) + ": failed on outer wire (" + ro.error().message + ")",
+                ro.error().code
+            });
+        }
+        total += ro.value();
+
+        const auto holes = face->holes_locked();
+        for (std::size_t i = 0; i < holes.size(); ++i) {
+            if (!holes[i]) {
+                return topo::Result<real>(topo::ResultError{
+                    face_ctx(face) + ": hole wire is null or expired at index " + std::to_string(i),
+                    topo::ErrorCode::topology_error
+                });
+            }
+
+            const auto rh = signed_area_of_wire_polygon(holes[i], curves, options);
+            if (!rh) {
+                return topo::Result<real>(topo::ResultError{
+                    face_ctx(face) + ": failed on hole wire index " + std::to_string(i) +
+                    " (" + rh.error().message + ")",
+                    rh.error().code
+                });
+            }
+            total += rh.value();
+        }
+
+        return topo::Result<real>(total);
+    }
+
+    topo::Result<bool> face_has_standard_orientation(const std::shared_ptr<topo::Face>& face,
+                                                     const geom::CurveStore& curves,
+                                                     const FaceAreaOptions& options) {
+        if (!face) {
+            return topo::Result<bool>(topo::ResultError{
+                "FaceArea: face pointer is null",
+                topo::ErrorCode::invalid_input
+            });
+        }
+
+        const auto outer = face->outer();
+        if (!outer) {
+            return topo::Result<bool>(topo::ResultError{
+                face_ctx(face) + ": outer wire is null or expired",
+                topo::ErrorCode::topology_error
+            });
+        }
+
+        const auto ro = classify_wire_orientation(outer, curves, options);
+        if (!ro) {
+            return topo::Result<bool>(topo::ResultError{
+                face_ctx(face) + ": failed to classify outer wire (" + ro.error().message + ")",
+                ro.error().code
+            });
+        }
+
+        if (ro.value() != LoopOrientation::ccw) {
+            return topo::Result<bool>(false);
+        }
+
+        const auto holes = face->holes_locked();
+        for (std::size_t i = 0; i < holes.size(); ++i) {
+            if (!holes[i]) {
+                return topo::Result<bool>(topo::ResultError{
+                    face_ctx(face) + ": hole wire is null or expired at index " + std::to_string(i),
+                    topo::ErrorCode::topology_error
+                });
+            }
+
+            const auto rh = classify_wire_orientation(holes[i], curves, options);
+            if (!rh) {
+                return topo::Result<bool>(topo::ResultError{
+                    face_ctx(face) + ": failed to classify hole wire index " + std::to_string(i) +
+                    " (" + rh.error().message + ")",
+                    rh.error().code
+                });
+            }
+
+            if (rh.value() != LoopOrientation::cw) {
+                return topo::Result<bool>(false);
+            }
+        }
+
+        return topo::Result<bool>(true);
+    }
+
+    topo::Result<bool> reverse_wire_using_twins(const std::shared_ptr<topo::Wire>& wire,
+                                                const FaceAreaOptions& options) {
+        if (!wire) {
+            return topo::Result<bool>(topo::ResultError{
+                "FaceArea: wire pointer is null",
+                topo::ErrorCode::invalid_input
+            });
+        }
+
+        const auto edges = wire->edges_locked();
+        if (edges.empty()) {
+            return topo::Result<bool>(topo::ResultError{
+                wire_ctx(wire) + ": wire boundary is empty",
+                topo::ErrorCode::invalid_input
+            });
+        }
+
+        std::vector<std::shared_ptr<topo::HalfEdge>> reversed;
+        reversed.reserve(edges.size());
+
+        for (auto it = edges.rbegin(); it != edges.rend(); ++it) {
+            if (!(*it)) {
+                return topo::Result<bool>(topo::ResultError{
+                    wire_ctx(wire) + ": wire contains a null or expired half-edge",
+                    topo::ErrorCode::topology_error
+                });
+            }
+
+            const auto twin = (*it)->twin();
+            if (!twin) {
+                return topo::Result<bool>(topo::ResultError{
+                    wire_ctx(wire) + ": cannot reverse wire because half-edge id=" +
+                    std::to_string((*it)->id()) + " has no twin",
+                    topo::ErrorCode::topology_error
+                });
+            }
+
+            reversed.push_back(twin);
+        }
+
+        std::vector<std::weak_ptr<topo::HalfEdge>> boundary;
+        boundary.reserve(reversed.size());
+        for (const auto& e : reversed) {
+            boundary.emplace_back(e);
+        }
+        wire->set_boundary(std::move(boundary));
+
+        if (options.update_next_prev_on_normalize) {
+            const std::size_t n = reversed.size();
+            for (std::size_t i = 0; i < n; ++i) {
+                const auto& curr = reversed[i];
+                const auto& next = reversed[(i + 1) % n];
+                const auto& prev = reversed[(i + n - 1) % n];
+                curr->set_next(next);
+                curr->set_prev(prev);
+            }
+        }
+
+        return topo::Result<bool>(true);
+    }
+
+    topo::Result<bool> normalize_face_polygon_orientations(const std::shared_ptr<topo::Face>& face,
+                                                           const geom::CurveStore& curves,
+                                                           const FaceAreaOptions& options) {
+        if (!face) {
+            return topo::Result<bool>(topo::ResultError{
+                "FaceArea: face pointer is null",
+                topo::ErrorCode::invalid_input
+            });
+        }
+
+        bool changed = false;
+
+        const auto outer = face->outer();
+        if (!outer) {
+            return topo::Result<bool>(topo::ResultError{
+                face_ctx(face) + ": outer wire is null or expired",
+                topo::ErrorCode::topology_error
+            });
+        }
+
+        const auto ro = normalize_wire_if_needed(outer, LoopOrientation::ccw, curves, options);
+        if (!ro) {
+            return topo::Result<bool>(topo::ResultError{
+                face_ctx(face) + ": failed to normalize outer wire (" + ro.error().message + ")",
+                ro.error().code
+            });
+        }
+        changed = changed || ro.value();
+
+        const auto holes = face->holes_locked();
+        for (std::size_t i = 0; i < holes.size(); ++i) {
+            if (!holes[i]) {
+                return topo::Result<bool>(topo::ResultError{
+                    face_ctx(face) + ": hole wire is null or expired at index " + std::to_string(i),
+                    topo::ErrorCode::topology_error
+                });
+            }
+
+            const auto rh = normalize_wire_if_needed(holes[i], LoopOrientation::cw, curves, options);
+            if (!rh) {
+                return topo::Result<bool>(topo::ResultError{
+                    face_ctx(face) + ": failed to normalize hole wire index " + std::to_string(i) +
+                    " (" + rh.error().message + ")",
+                    rh.error().code
+                });
+            }
+            changed = changed || rh.value();
+        }
+
+        return topo::Result<bool>(changed);
+    }
+}

--- a/tests/cad2d/CMakeLists.txt
+++ b/tests/cad2d/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(test_cad2d_validate
         edge_builder_tests.cxx
         edge_validation_tests.cxx
         wire_length_tests.cxx
+        face_area_tests.cxx
 )
 
 target_link_libraries(test_cad2d_validate PRIVATE

--- a/tests/cad2d/face_area_tests.cxx
+++ b/tests/cad2d/face_area_tests.cxx
@@ -1,0 +1,171 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file face_area_tests.cxx
+ * @brief Unit tests for polygonal face-area and orientation utilities.
+ */
+#include <gtest/gtest.h>
+
+#include <tonb/config.hxx>
+#include <tonb/cad2d/algo/face_area.hxx>
+#include <tonb/cad2d/tools.hxx>
+#include <tonb/cad2d/geom/curve_store.hxx>
+#include <tonb/cad2d/builder/halfedge_builder.hxx>
+#include <tonb/cad2d/builder/wire_builder.hxx>
+#include <tonb/cad2d/builder/face_builder.hxx>
+#include <tonb/cad2d/topo/shape.hxx>
+
+namespace tonb::cad2d::tests {
+
+TEST(Cad2dAlgo, SquareFaceSignedAreaIsOne)
+{
+#if !TONB_WITH_OCCT
+    GTEST_SKIP() << "TONB_WITH_OCCT disabled; skipping face-area geometry tests.";
+#else
+    topo::Shape shape;
+    geom::CurveStore store;
+    build::HalfEdgeBuilder edge_builder(shape);
+    build::WireBuilder wire_builder(shape, topo::Tolerance{});
+    build::FaceBuilder face_builder(shape, topo::Tolerance{});
+
+    auto v0 = shape.make_vertex({0.0, 0.0});
+    auto v1 = shape.make_vertex({1.0, 0.0});
+    auto v2 = shape.make_vertex({1.0, 1.0});
+    auto v3 = shape.make_vertex({0.0, 1.0});
+
+    ASSERT_TRUE(v0);
+    ASSERT_TRUE(v1);
+    ASSERT_TRUE(v2);
+    ASSERT_TRUE(v3);
+
+    const auto c01 = cad2d::Tools::make_segment({0.0, 0.0}, {1.0, 0.0});
+    const auto c12 = cad2d::Tools::make_segment({1.0, 0.0}, {1.0, 1.0});
+    const auto c23 = cad2d::Tools::make_segment({1.0, 1.0}, {0.0, 1.0});
+    const auto c30 = cad2d::Tools::make_segment({0.0, 1.0}, {0.0, 0.0});
+
+    const auto r01 = c01.parameter_range();
+    const auto r12 = c12.parameter_range();
+    const auto r23 = c23.parameter_range();
+    const auto r30 = c30.parameter_range();
+
+    ASSERT_TRUE(r01.has_value());
+    ASSERT_TRUE(r12.has_value());
+    ASSERT_TRUE(r23.has_value());
+    ASSERT_TRUE(r30.has_value());
+
+    auto e01 = edge_builder.create_from_curve(store, c01, v0, v1, r01->first, r01->second, topo::Orientation::forward);
+    auto e12 = edge_builder.create_from_curve(store, c12, v1, v2, r12->first, r12->second, topo::Orientation::forward);
+    auto e23 = edge_builder.create_from_curve(store, c23, v2, v3, r23->first, r23->second, topo::Orientation::forward);
+    auto e30 = edge_builder.create_from_curve(store, c30, v3, v0, r30->first, r30->second, topo::Orientation::forward);
+
+    ASSERT_TRUE(e01) << e01.error().message;
+    ASSERT_TRUE(e12) << e12.error().message;
+    ASSERT_TRUE(e23) << e23.error().message;
+    ASSERT_TRUE(e30) << e30.error().message;
+
+    auto outer = wire_builder.create({e01.value(), e12.value(), e23.value(), e30.value()}, true, true);
+    ASSERT_TRUE(outer) << outer.error().message;
+
+    auto face = face_builder.create(outer.value());
+    ASSERT_TRUE(face) << face.error().message;
+
+    algo::FaceAreaOptions options;
+    options.linearity_tolerance = 1.0e-10;
+    options.area_epsilon = 1.0e-12;
+
+    const auto area = algo::signed_area_of_face_polygon(face.value(), store, options);
+    ASSERT_TRUE(area) << area.error().message;
+    EXPECT_NEAR(area.value(), 1.0, 1.0e-10);
+
+    const auto orient = algo::face_has_standard_orientation(face.value(), store, options);
+    ASSERT_TRUE(orient) << orient.error().message;
+    EXPECT_TRUE(orient.value());
+#endif
+}
+
+TEST(Cad2dAlgo, FaceHoleSubtractsAreaCorrectly)
+{
+#if !TONB_WITH_OCCT
+    GTEST_SKIP() << "TONB_WITH_OCCT disabled; skipping face-area geometry tests.";
+#else
+    topo::Shape shape;
+    geom::CurveStore store;
+    build::HalfEdgeBuilder edge_builder(shape);
+    build::WireBuilder wire_builder(shape, topo::Tolerance{});
+    build::FaceBuilder face_builder(shape, topo::Tolerance{});
+
+    // Outer square: (0,0) -> (2,0) -> (2,2) -> (0,2), CCW, area = +4
+    auto o0 = shape.make_vertex({0.0, 0.0});
+    auto o1 = shape.make_vertex({2.0, 0.0});
+    auto o2 = shape.make_vertex({2.0, 2.0});
+    auto o3 = shape.make_vertex({0.0, 2.0});
+
+    // Inner square hole: (0.5,0.5) -> (0.5,1.5) -> (1.5,1.5) -> (1.5,0.5), CW, area = -1
+    auto h0 = shape.make_vertex({0.5, 0.5});
+    auto h1 = shape.make_vertex({0.5, 1.5});
+    auto h2 = shape.make_vertex({1.5, 1.5});
+    auto h3 = shape.make_vertex({1.5, 0.5});
+
+    ASSERT_TRUE(o0); ASSERT_TRUE(o1); ASSERT_TRUE(o2); ASSERT_TRUE(o3);
+    ASSERT_TRUE(h0); ASSERT_TRUE(h1); ASSERT_TRUE(h2); ASSERT_TRUE(h3);
+
+    auto make_edge = [&](const Point& a, const Point& b,
+                         const std::shared_ptr<topo::Vertex>& va,
+                         const std::shared_ptr<topo::Vertex>& vb)
+            -> topo::Result<std::shared_ptr<topo::HalfEdge>> {
+        const auto c = cad2d::Tools::make_segment(a, b);
+        const auto r = c.parameter_range();
+        if (!r.has_value()) {
+            return topo::Result<std::shared_ptr<topo::HalfEdge>>(topo::ResultError{
+                "FaceAreaTests: segment has no finite parameter range",
+                topo::ErrorCode::geometry_error
+            });
+        }
+        return edge_builder.create_from_curve(store, c, va, vb, r->first, r->second, topo::Orientation::forward);
+    };
+
+    auto oe0 = make_edge({0.0, 0.0}, {2.0, 0.0}, o0, o1);
+    auto oe1 = make_edge({2.0, 0.0}, {2.0, 2.0}, o1, o2);
+    auto oe2 = make_edge({2.0, 2.0}, {0.0, 2.0}, o2, o3);
+    auto oe3 = make_edge({0.0, 2.0}, {0.0, 0.0}, o3, o0);
+
+    auto he0 = make_edge({0.5, 0.5}, {0.5, 1.5}, h0, h1);
+    auto he1 = make_edge({0.5, 1.5}, {1.5, 1.5}, h1, h2);
+    auto he2 = make_edge({1.5, 1.5}, {1.5, 0.5}, h2, h3);
+    auto he3 = make_edge({1.5, 0.5}, {0.5, 0.5}, h3, h0);
+
+    ASSERT_TRUE(oe0) << oe0.error().message;
+    ASSERT_TRUE(oe1) << oe1.error().message;
+    ASSERT_TRUE(oe2) << oe2.error().message;
+    ASSERT_TRUE(oe3) << oe3.error().message;
+
+    ASSERT_TRUE(he0) << he0.error().message;
+    ASSERT_TRUE(he1) << he1.error().message;
+    ASSERT_TRUE(he2) << he2.error().message;
+    ASSERT_TRUE(he3) << he3.error().message;
+
+    auto outer = wire_builder.create({oe0.value(), oe1.value(), oe2.value(), oe3.value()}, true, true);
+    auto hole  = wire_builder.create({he0.value(), he1.value(), he2.value(), he3.value()}, true, true);
+
+    ASSERT_TRUE(outer) << outer.error().message;
+    ASSERT_TRUE(hole) << hole.error().message;
+
+    auto face = face_builder.create(outer.value(), {hole.value()});
+    ASSERT_TRUE(face) << face.error().message;
+
+    algo::FaceAreaOptions options;
+    options.linearity_tolerance = 1.0e-10;
+    options.area_epsilon = 1.0e-12;
+
+    const auto area = algo::signed_area_of_face_polygon(face.value(), store, options);
+    ASSERT_TRUE(area) << area.error().message;
+    EXPECT_NEAR(area.value(), 3.0, 1.0e-10);
+
+    const auto orient = algo::face_has_standard_orientation(face.value(), store, options);
+    ASSERT_TRUE(orient) << orient.error().message;
+    EXPECT_TRUE(orient.value());
+#endif
+}
+
+} // namespace tonb::cad2d::tests


### PR DESCRIPTION
- add signed polygonal area computation for wires and faces in `cad2d/algo`
- add loop orientation classification based on signed-area sign
- document and enforce the standard face convention of outer CCW and holes CW
- add face-orientation checks and normalization helpers using existing twin half-edges
- restrict the current implementation to segment-only / polygonal spans with explicit rejection of non-linear geometry
- add regression coverage for unit-square face area and hole area subtraction