### PR TITLE
feat(cad2d): add public 2D intersection result types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@ All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Highlights
+- **Public 2D intersection result model introduced for cad2d**: Added the first public, kernel-agnostic result types for 2D curve-curve intersection queries, covering isolated points, tangent points, overlap intervals, and explicit unsupported/failure outcomes.
+- **Curve intersections foundation started**: Began Milestone vNext+4 by defining the public API surface that later intersection implementations will return without forcing future redesign of the result model.
+
+### Added
+- **Public intersection result types in `cad2d/geom`**:
+    - result model for isolated point intersections with parameters on both input curves
+    - result model for overlap / coincident intervals with parameter spans on both input curves
+    - explicit tangent-point classification where relevant
+    - explicit unsupported and failure outcomes with stable diagnostics
+- **Intersection result diagnostics**:
+    - stable, documented representation of empty successful queries versus unsupported/failure cases
+    - kernel-agnostic public API surface even when future implementations are backed internally by OCCT
+- **Intersection result test coverage**:
+    - regression test for line-line style crossing represented as one point with parameters on both curves
+    - regression test for disjoint query represented as a successful empty intersection result
+    - regression test for coincident overlapping segment-style query represented as overlap interval rather than ambiguous point output
+    - regression test for tangent-point classification and explicit unsupported/failure diagnostics
+
+### Notes
+- This begins **Milestone vNext+4 — Curve Intersections Foundation**.
+- Issue 8 currently covers the **public result-type and API model only**. The actual bounded span intersection implementation remains the next step.
+
+---
+
 ## [0.20.0] - 2026-05-07
 
 ### Highlights

--- a/libs/cad2d/CMakeLists.txt
+++ b/libs/cad2d/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(TonbCAD2d
         src/validate/edge_checks.cxx
         src/geom/curve_store.cxx
         src/geom/curve_ops.cxx
+        src/geom/intersection_result.cxx
         src/algo/wire_length.cxx
         src/algo/face_area.cxx
         PUBLIC
@@ -110,6 +111,7 @@ target_sources(TonbCAD2d
         include/tonb/cad2d/validate/edge_checks.hxx
         include/tonb/cad2d/geom/curve_store.hxx
         include/tonb/cad2d/geom/curve_ops.hxx
+        include/tonb/cad2d/geom/intersection_result.hxx
         include/tonb/cad2d/algo/wire_length.hxx
         include/tonb/cad2d/algo/face_area.hxx
 )

--- a/libs/cad2d/include/tonb/cad2d/geom/intersection_result.hxx
+++ b/libs/cad2d/include/tonb/cad2d/geom/intersection_result.hxx
@@ -1,0 +1,278 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file intersection_result.hxx
+ * @brief Declares public kernel-agnostic result types for 2D curve-curve intersections.
+ *
+ * This header defines the public result model for 2D curve-curve intersection
+ * queries in cad2d. The intent is to expose a stable, geometry-kernel-agnostic
+ * API surface at the cad2d layer even if the underlying implementation is
+ * backed by OCCT or another kernel internally.
+ *
+ * Design goals
+ * ------------
+ * - represent isolated point intersections explicitly
+ * - represent coincident / overlapping span intersections explicitly
+ * - represent tangent intersections without collapsing them into the same
+ *   category as ordinary transverse crossings
+ * - expose parameters on both input curves
+ * - expose explicit diagnostics for unsupported or failed queries
+ *
+ * Scope
+ * -----
+ * This file defines public data types only. It does not implement any specific
+ * intersection algorithm. Later issues should consume these types from public
+ * curve-curve and topology-level intersection APIs.
+ */
+#pragma once
+#ifndef TONB_CAD2D_GEOM_INTERSECTION_RESULT_HXX
+#define TONB_CAD2D_GEOM_INTERSECTION_RESULT_HXX
+
+#include <tonb/cad2d/module.hxx>
+#include <tonb/cad2d/point.hxx>
+#include <tonb/cad2d/topo/result.hxx>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace tonb::cad2d::geom {
+
+    /**
+     * @brief Describes the broad outcome class of an intersection query.
+     */
+    enum class CurveIntersectionStatus : std::uint8_t {
+        success = 0,      ///< Query completed successfully; @ref items contains the result set.
+        unsupported,      ///< Query combination or geometry type is not supported by the current implementation.
+        failure           ///< Query failed due to invalid geometry, kernel failure, or internal error.
+    };
+
+    /**
+     * @brief Classifies the local character of an isolated intersection point.
+     */
+    enum class CurveIntersectionPointKind : std::uint8_t {
+        simple = 0,       ///< Ordinary isolated crossing.
+        tangent           ///< Tangential contact at the reported point.
+    };
+
+    /**
+     * @brief Describes the kind of one intersection item in the result set.
+     */
+    enum class CurveIntersectionItemKind : std::uint8_t {
+        point = 0,        ///< One isolated point intersection.
+        overlap           ///< One coincident / overlapping bounded span.
+    };
+
+    /**
+     * @brief Represents one isolated point intersection between two bounded curve spans.
+     *
+     * The same geometric point is described by one parameter value on each input
+     * curve. The point kind records whether the local interaction is simple or
+     * tangential.
+     */
+    struct CurveIntersectionPoint {
+        Point point;                                      ///< Geometric intersection point.
+        real u_on_first = 0.0;                            ///< Parameter on the first curve/span.
+        real u_on_second = 0.0;                           ///< Parameter on the second curve/span.
+        CurveIntersectionPointKind kind =
+            CurveIntersectionPointKind::simple;           ///< Local point-intersection character.
+    };
+
+    /**
+     * @brief Represents one bounded coincident / overlapping span between two curves.
+     *
+     * Overlap is expressed through corresponding parameter intervals on both
+     * input curves. The geometric endpoints are included explicitly to avoid
+     * ambiguity and to keep the public result model convenient for diagnostics,
+     * visualisation, and later topology-level splitting code.
+     */
+    struct CurveIntersectionOverlap {
+        Point first_point;                                ///< Geometric start point of the overlap interval.
+        Point last_point;                                 ///< Geometric end point of the overlap interval.
+        real first_u0 = 0.0;                              ///< Start parameter on the first curve/span.
+        real first_u1 = 0.0;                              ///< End parameter on the first curve/span.
+        real second_u0 = 0.0;                             ///< Start parameter on the second curve/span.
+        real second_u1 = 0.0;                             ///< End parameter on the second curve/span.
+    };
+
+    /**
+     * @brief Variant representing one element of the intersection result set.
+     */
+    using CurveIntersectionItem = std::variant<CurveIntersectionPoint, CurveIntersectionOverlap>;
+
+    /**
+     * @brief Public result container for one 2D curve-curve intersection query.
+     *
+     * When @ref status is @ref CurveIntersectionStatus::success, the query
+     * completed successfully and @ref items contains zero or more intersection
+     * items. A successful query with an empty item set represents the common
+     * "no intersections" case.
+     *
+     * When @ref status is not success, the query did not produce a usable result
+     * set and @ref diagnostic should explain why.
+     */
+    struct CurveIntersectionReport {
+        CurveIntersectionStatus status = CurveIntersectionStatus::success; ///< Overall query outcome.
+        std::vector<CurveIntersectionItem> items;                         ///< Ordered result items.
+        std::string diagnostic;                                           ///< Explicit diagnostic for unsupported/failure cases.
+
+        /**
+         * @brief Return true if the query completed successfully.
+         */
+        TNB_NODISCARD bool ok() const noexcept {
+            return status == CurveIntersectionStatus::success;
+        }
+
+        /**
+         * @brief Return true if the successful query produced no intersections.
+         */
+        TNB_NODISCARD bool empty() const noexcept {
+            return items.empty();
+        }
+
+        /**
+         * @brief Count isolated point intersections in @ref items.
+         */
+        TNB_NODISCARD std::size_t point_count() const noexcept {
+            std::size_t n = 0;
+            for (const auto& item : items) {
+                if (std::holds_alternative<CurveIntersectionPoint>(item)) {
+                    ++n;
+                }
+            }
+            return n;
+        }
+
+        /**
+         * @brief Count overlap intersections in @ref items.
+         */
+        TNB_NODISCARD std::size_t overlap_count() const noexcept {
+            std::size_t n = 0;
+            for (const auto& item : items) {
+                if (std::holds_alternative<CurveIntersectionOverlap>(item)) {
+                    ++n;
+                }
+            }
+            return n;
+        }
+
+        /**
+         * @brief Return true if any overlap item is present.
+         */
+        TNB_NODISCARD bool has_overlap() const noexcept {
+            return overlap_count() > 0;
+        }
+    };
+
+    /**
+     * @brief Construct a successful empty intersection report.
+     *
+     * This represents a valid query that found no intersections.
+     */
+    TNB_NODISCARD inline CurveIntersectionReport make_no_intersections() {
+        return CurveIntersectionReport{};
+    }
+
+    /**
+     * @brief Construct a successful report from one isolated point item.
+     *
+     * @param point Geometric intersection point.
+     * @param u_on_first Parameter on the first curve/span.
+     * @param u_on_second Parameter on the second curve/span.
+     * @param kind Local point-intersection character.
+     * @return Successful report containing one point item.
+     */
+    TNB_NODISCARD inline CurveIntersectionReport make_point_intersection(
+        const Point& point,
+        const real u_on_first,
+        const real u_on_second,
+        const CurveIntersectionPointKind kind = CurveIntersectionPointKind::simple) {
+
+        CurveIntersectionReport out;
+        out.items.emplace_back(CurveIntersectionPoint{
+            point,
+            u_on_first,
+            u_on_second,
+            kind
+        });
+        return out;
+    }
+
+    /**
+     * @brief Construct a successful report from one overlap item.
+     *
+     * @param first_point Geometric start point of the overlap interval.
+     * @param last_point Geometric end point of the overlap interval.
+     * @param first_u0 Start parameter on the first curve/span.
+     * @param first_u1 End parameter on the first curve/span.
+     * @param second_u0 Start parameter on the second curve/span.
+     * @param second_u1 End parameter on the second curve/span.
+     * @return Successful report containing one overlap item.
+     */
+    TNB_NODISCARD inline CurveIntersectionReport make_overlap_intersection(
+        const Point& first_point,
+        const Point& last_point,
+        const real first_u0,
+        const real first_u1,
+        const real second_u0,
+        const real second_u1) {
+
+        CurveIntersectionReport out;
+        out.items.emplace_back(CurveIntersectionOverlap{
+            first_point,
+            last_point,
+            first_u0,
+            first_u1,
+            second_u0,
+            second_u1
+        });
+        return out;
+    }
+
+    /**
+     * @brief Construct an unsupported intersection report with explicit diagnostic.
+     *
+     * @param diagnostic Stable human-readable explanation.
+     * @return Unsupported report.
+     */
+    TNB_NODISCARD inline CurveIntersectionReport make_unsupported_intersection(
+        std::string diagnostic) {
+
+        CurveIntersectionReport out;
+        out.status = CurveIntersectionStatus::unsupported;
+        out.diagnostic = std::move(diagnostic);
+        return out;
+    }
+
+    /**
+     * @brief Construct a failed intersection report with explicit diagnostic.
+     *
+     * @param diagnostic Stable human-readable explanation.
+     * @return Failure report.
+     */
+    TNB_NODISCARD inline CurveIntersectionReport make_failed_intersection(
+        std::string diagnostic) {
+
+        CurveIntersectionReport out;
+        out.status = CurveIntersectionStatus::failure;
+        out.diagnostic = std::move(diagnostic);
+        return out;
+    }
+
+    /**
+     * @brief Return the item kind of one result item.
+     *
+     * @param item Item to inspect.
+     * @return Point or overlap classification.
+     */
+    TNB_NODISCARD inline CurveIntersectionItemKind item_kind(const CurveIntersectionItem& item) noexcept {
+        return std::holds_alternative<CurveIntersectionPoint>(item)
+            ? CurveIntersectionItemKind::point
+            : CurveIntersectionItemKind::overlap;
+    }
+}
+
+#endif // TONB_CAD2D_GEOM_INTERSECTION_RESULT_HXX

--- a/libs/cad2d/src/geom/intersection_result.cxx
+++ b/libs/cad2d/src/geom/intersection_result.cxx
@@ -1,0 +1,3 @@
+//
+// Created by amir on 5/7/26.
+//

--- a/tests/cad2d/CMakeLists.txt
+++ b/tests/cad2d/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(test_cad2d_validate
         edge_validation_tests.cxx
         wire_length_tests.cxx
         face_area_tests.cxx
+        intersection_result_tests.cxx
 )
 
 target_link_libraries(test_cad2d_validate PRIVATE

--- a/tests/cad2d/intersection_result_tests.cxx
+++ b/tests/cad2d/intersection_result_tests.cxx
@@ -1,0 +1,121 @@
+//
+// Created by amir on 5/7/26.
+//
+/**
+ * @file intersection_result_tests.cxx
+ * @brief Tests for the public 2D intersection result model.
+ *
+ * These tests intentionally validate the public result types themselves rather
+ * than any specific geometry-kernel intersection implementation. The goal of
+ * Issue 8 is to establish a stable public result model that can already
+ * distinguish:
+ * - isolated point intersections,
+ * - no-intersection successful queries,
+ * - coincident overlap intervals,
+ * - unsupported/failure diagnostics.
+ */
+#include <gtest/gtest.h>
+
+#include <tonb/cad2d/geom/intersection_result.hxx>
+
+namespace tonb::cad2d::tests {
+
+TEST(Cad2dGeomIntersectionResult, LineLineCrossingCanBeRepresentedAsOnePoint)
+{
+    const auto report = geom::make_point_intersection(
+        Point{0.5, 0.5},
+        0.5,
+        0.5,
+        geom::CurveIntersectionPointKind::simple);
+
+    ASSERT_TRUE(report.ok());
+    ASSERT_FALSE(report.empty());
+    EXPECT_EQ(report.point_count(), 1u);
+    EXPECT_EQ(report.overlap_count(), 0u);
+    ASSERT_EQ(report.items.size(), 1u);
+
+    ASSERT_TRUE(std::holds_alternative<geom::CurveIntersectionPoint>(report.items.front()));
+    const auto& item = std::get<geom::CurveIntersectionPoint>(report.items.front());
+
+    EXPECT_DOUBLE_EQ(item.point.x(), 0.5);
+    EXPECT_DOUBLE_EQ(item.point.y(), 0.5);
+    EXPECT_DOUBLE_EQ(item.u_on_first, 0.5);
+    EXPECT_DOUBLE_EQ(item.u_on_second, 0.5);
+    EXPECT_EQ(item.kind, geom::CurveIntersectionPointKind::simple);
+}
+
+TEST(Cad2dGeomIntersectionResult, DisjointLineLineCanBeRepresentedAsEmptySuccess)
+{
+    const auto report = geom::make_no_intersections();
+
+    ASSERT_TRUE(report.ok());
+    EXPECT_TRUE(report.empty());
+    EXPECT_EQ(report.point_count(), 0u);
+    EXPECT_EQ(report.overlap_count(), 0u);
+    EXPECT_TRUE(report.diagnostic.empty());
+}
+
+TEST(Cad2dGeomIntersectionResult, CoincidentOverlapCanBeRepresentedWithoutAmbiguousPoints)
+{
+    const auto report = geom::make_overlap_intersection(
+        Point{1.0, 0.0},
+        Point{2.0, 0.0},
+        1.0,
+        2.0,
+        0.0,
+        1.0);
+
+    ASSERT_TRUE(report.ok());
+    ASSERT_FALSE(report.empty());
+    EXPECT_EQ(report.point_count(), 0u);
+    EXPECT_EQ(report.overlap_count(), 1u);
+    EXPECT_TRUE(report.has_overlap());
+    ASSERT_EQ(report.items.size(), 1u);
+
+    ASSERT_TRUE(std::holds_alternative<geom::CurveIntersectionOverlap>(report.items.front()));
+    const auto& item = std::get<geom::CurveIntersectionOverlap>(report.items.front());
+
+    EXPECT_DOUBLE_EQ(item.first_point.x(), 1.0);
+    EXPECT_DOUBLE_EQ(item.first_point.y(), 0.0);
+    EXPECT_DOUBLE_EQ(item.last_point.x(), 2.0);
+    EXPECT_DOUBLE_EQ(item.last_point.y(), 0.0);
+    EXPECT_DOUBLE_EQ(item.first_u0, 1.0);
+    EXPECT_DOUBLE_EQ(item.first_u1, 2.0);
+    EXPECT_DOUBLE_EQ(item.second_u0, 0.0);
+    EXPECT_DOUBLE_EQ(item.second_u1, 1.0);
+}
+
+TEST(Cad2dGeomIntersectionResult, TangentPointKindIsDistinguishedExplicitly)
+{
+    const auto report = geom::make_point_intersection(
+        Point{1.0, 1.0},
+        2.0,
+        3.0,
+        geom::CurveIntersectionPointKind::tangent);
+
+    ASSERT_TRUE(report.ok());
+    ASSERT_EQ(report.items.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<geom::CurveIntersectionPoint>(report.items.front()));
+
+    const auto& item = std::get<geom::CurveIntersectionPoint>(report.items.front());
+    EXPECT_EQ(item.kind, geom::CurveIntersectionPointKind::tangent);
+}
+
+TEST(Cad2dGeomIntersectionResult, UnsupportedAndFailureDiagnosticsAreExplicit)
+{
+    const auto unsupported = geom::make_unsupported_intersection(
+        "CurveIntersection: curve combination is not supported");
+    ASSERT_FALSE(unsupported.ok());
+    EXPECT_EQ(unsupported.status, geom::CurveIntersectionStatus::unsupported);
+    EXPECT_EQ(unsupported.items.size(), 0u);
+    EXPECT_EQ(unsupported.diagnostic, "CurveIntersection: curve combination is not supported");
+
+    const auto failure = geom::make_failed_intersection(
+        "CurveIntersection: kernel evaluation failed");
+    ASSERT_FALSE(failure.ok());
+    EXPECT_EQ(failure.status, geom::CurveIntersectionStatus::failure);
+    EXPECT_EQ(failure.items.size(), 0u);
+    EXPECT_EQ(failure.diagnostic, "CurveIntersection: kernel evaluation failed");
+}
+
+} // namespace tonb::cad2d::tests


### PR DESCRIPTION
- add kernel-agnostic public result types for 2D curve-curve intersection queries in `cad2d/geom`
- distinguish isolated point intersections from overlap / coincident interval results
- include parameter values on both input curves for point and overlap cases
- add explicit tangent-point classification where relevant
- represent disjoint successful queries separately from unsupported/failure outcomes
- add regression coverage for point, disjoint, overlap, tangent, and diagnostic result cases