### PR TITLE
feat(shell): add cad2d command registry and dispatch foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - **cad2d shell module scaffolded for future expansion**: Added the initial `ShellApp` façade, Tonb-native shell export macros, placeholder shell runtime headers, and basic smoke-test coverage so later session, tokenisation, UI, and command infrastructure can be developed on a real module boundary.
 - **cad2d shell session model introduced**: Added the first real `ShellSession` orchestration root for `shell/cad2d`, with named curve-store and shape domains, active-context tracking, shape-to-curve-store binding, primary selection, runtime flags, and deterministic status/reset support.
 - **Session foundation prepared for CAD-like growth**: The new shell session model is intentionally structured to support future selection-set, alias-handle, journaling, and undo/redo style workflows without embedding CAD algorithms into the shell state layer.
+- **cad2d command registry and dispatch foundation introduced**: Added the first real hierarchical command infrastructure for `shell/cad2d`, with deterministic path lookup, alias support, structured command dispatch, and explicit invalid-command failures.
+- **Command infrastructure aligned with future shell growth**: The new registry/context/args model is designed to support later command families, help integration, tokenisation, and AutoCAD-like command workflows without collapsing everything into ad hoc handlers.
 
 ### Added
 - **Root-level Tonb foundation module**:
@@ -74,6 +76,21 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - regression tests for deterministic session creation and reset behavior
     - regression tests for active shape and active curve-store assignment
     - regression tests for storing and reporting shape-to-curve-store bindings
+- **cad2d command registry and dispatch infrastructure**:
+    - hierarchical command path model for shell command registration and lookup
+    - structured command argument model for dispatch-time token handling
+    - command execution context carrying session access and dispatch-facing state
+    - command node and registry types for clean command-family registration
+    - deterministic longest-prefix or equivalent path matching for nested commands
+    - alias support for command-path dispatch
+    - explicit unknown-command failure behavior
+    - deterministic rejection of conflicting alias or command registrations
+- **cad2d command infrastructure test coverage**:
+    - regression tests for simple command dispatch
+    - regression tests for nested command dispatch
+    - regression tests for clean unknown-command failure
+    - regression tests for alias dispatch behavior
+    - regression tests ensuring ambiguous or conflicting command registration is prevented deterministically
 
 ### Changed
 - **Foundation namespace and include adaptation**:
@@ -83,6 +100,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - aligned the imported foundation layer with Tonb build, target, and install conventions
     - extended the root build to include the new `shell/cad2d` module
     - extended the shell module build to compile and test the first real session subsystem
+    - extended the shell module build further to compile and test the first real command infrastructure subsystem
 - **Bundle integrity implementation cleanup**:
     - removed an unnecessary OpenSSL include during the Tonb port of the foundation bundle-integrity implementation
 
@@ -92,7 +110,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - The current integration keeps the module structure broad and reusable so it can later be split further if needed.
 - This completes **Issue 1 — Root-level cad2d Shell Module** from the cad2d shell roadmap.
 - This also completes **Issue 2 — Shell Session Model** from the cad2d shell roadmap.
-- The current `shell/cad2d` state now includes a real session foundation, but tokenisation, UI, command dispatch, and help infrastructure remain future issues built on top of this boundary.
+- This also completes **Issue 3 — Command Registry and Dispatch Infrastructure** from the cad2d shell roadmap.
+- The current `shell/cad2d` state now includes a real session foundation and command dispatch foundation, but help rendering, tokenisation, and higher-level command families remain future issues built on top of this boundary.
 
 ---
 

--- a/shell/cad2d/CMakeLists.txt
+++ b/shell/cad2d/CMakeLists.txt
@@ -5,6 +5,8 @@ target_sources(TonbCAD2dShell
         PRIVATE
         src/shell_app.cxx
         src/shell_session.cxx
+        src/command/command_registry.cxx
+        src/command/command_node.cxx
         PUBLIC
         FILE_SET HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -12,6 +14,10 @@ target_sources(TonbCAD2dShell
         include/tonb/cad2d/shell/module.hxx
         include/tonb/cad2d/shell/shell_app.hxx
         include/tonb/cad2d/shell/shell_session.hxx
+        include/tonb/cad2d/shell/command/command_registry.hxx
+        include/tonb/cad2d/shell/command/command_args.hxx
+        include/tonb/cad2d/shell/command/command_context.hxx
+        include/tonb/cad2d/shell/command/command_node.hxx
 )
 
 target_include_directories(TonbCAD2dShell PUBLIC

--- a/shell/cad2d/include/tonb/cad2d/shell/command/command_args.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/command/command_args.hxx
@@ -1,0 +1,75 @@
+#pragma once
+#ifndef TONB_CAD2D_SHELL_COMMAND_COMMAND_ARGS_HXX
+#define TONB_CAD2D_SHELL_COMMAND_COMMAND_ARGS_HXX
+
+#include <cstddef>
+#include <initializer_list>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <tonb/cad2d/shell/module.hxx>
+
+namespace tonb::cad2d::shell::command {
+
+    /**
+     * @brief Non-owning-style command-argument container for dispatched shell handlers.
+     *
+     * The command registry consumes the matched command path and passes the remaining
+     * user tokens to the command handler through this lightweight value container.
+     */
+    class CommandArgs {
+    public:
+        CommandArgs() = default;
+        CommandArgs(std::initializer_list<std::string> values)
+            : tokens_(values) {
+        }
+        explicit CommandArgs(std::vector<std::string> values)
+            : tokens_(std::move(values)) {
+        }
+
+        TNB_NODISCARD std::size_t size() const noexcept {
+            return tokens_.size();
+        }
+
+        TNB_NODISCARD bool empty() const noexcept {
+            return tokens_.empty();
+        }
+
+        TNB_NODISCARD const std::vector<std::string>& tokens() const noexcept {
+            return tokens_;
+        }
+
+        TNB_NODISCARD std::string_view operator[](const std::size_t index) const {
+            return tokens_.at(index);
+        }
+
+        TNB_NODISCARD std::string_view at(const std::size_t index) const {
+            return tokens_.at(index);
+        }
+
+    private:
+        std::vector<std::string> tokens_;
+    };
+
+    /**
+     * @brief Structured command-handler result.
+     */
+    struct CommandResult {
+        bool ok = true;
+        std::string message;
+
+        TNB_NODISCARD static CommandResult success(std::string message = {}) {
+            return CommandResult{true, std::move(message)};
+        }
+
+        TNB_NODISCARD static CommandResult failure(std::string message) {
+            return CommandResult{false, std::move(message)};
+        }
+    };
+
+} // namespace tonb::cad2d::shell::command
+
+#endif // TONB_CAD2D_SHELL_COMMAND_COMMAND_ARGS_HXX

--- a/shell/cad2d/include/tonb/cad2d/shell/command/command_context.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/command/command_context.hxx
@@ -1,0 +1,50 @@
+#pragma once
+#ifndef TONB_CAD2D_SHELL_COMMAND_COMMAND_CONTEXT_HXX
+#define TONB_CAD2D_SHELL_COMMAND_COMMAND_CONTEXT_HXX
+
+#include <iosfwd>
+
+#include <tonb/cad2d/shell/module.hxx>
+
+namespace tonb::cad2d::shell {
+    class ShellSession;
+}
+
+namespace tonb::cad2d::shell::command {
+
+    /**
+     * @brief Lightweight runtime context passed to command handlers.
+     *
+     * The context intentionally stays small and non-owning. It is designed to
+     * mirror the iXFract-style shell command context without embedding registry,
+     * parsing, or CAD algorithm state into handlers themselves.
+     */
+    class CommandContext {
+    public:
+        explicit CommandContext(shell::ShellSession* session = nullptr,
+                                std::ostream* out = nullptr,
+                                std::ostream* err = nullptr) noexcept
+            : session_(session), out_(out), err_(err) {
+        }
+
+        TNB_NODISCARD shell::ShellSession* session() const noexcept {
+            return session_;
+        }
+
+        TNB_NODISCARD std::ostream* out() const noexcept {
+            return out_;
+        }
+
+        TNB_NODISCARD std::ostream* err() const noexcept {
+            return err_;
+        }
+
+    private:
+        shell::ShellSession* session_ = nullptr;
+        std::ostream* out_ = nullptr;
+        std::ostream* err_ = nullptr;
+    };
+
+} // namespace tonb::cad2d::shell::command
+
+#endif // TONB_CAD2D_SHELL_COMMAND_COMMAND_CONTEXT_HXX

--- a/shell/cad2d/include/tonb/cad2d/shell/command/command_node.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/command/command_node.hxx
@@ -1,0 +1,59 @@
+#pragma once
+#ifndef TONB_CAD2D_SHELL_COMMAND_COMMAND_NODE_HXX
+#define TONB_CAD2D_SHELL_COMMAND_COMMAND_NODE_HXX
+
+#include <cstddef>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+#include <tonb/cad2d/shell/module.hxx>
+
+namespace tonb::cad2d::shell::command {
+
+    /**
+     * @brief Canonical command path value type.
+     */
+    class CommandPath {
+    public:
+        CommandPath() = default;
+        explicit CommandPath(std::vector<std::string> segments);
+        CommandPath(std::initializer_list<std::string> segments);
+
+        TNB_NODISCARD const std::vector<std::string>& segments() const noexcept {
+            return segments_;
+        }
+
+        TNB_NODISCARD std::size_t size() const noexcept {
+            return segments_.size();
+        }
+
+        TNB_NODISCARD bool empty() const noexcept {
+            return segments_.empty();
+        }
+
+        TNB_NODISCARD std::string to_string() const;
+
+        TNB_NODISCARD bool operator==(const CommandPath& other) const noexcept {
+            return segments_ == other.segments_;
+        }
+
+        TNB_NODISCARD bool operator<(const CommandPath& other) const noexcept {
+            return segments_ < other.segments_;
+        }
+
+    private:
+        std::vector<std::string> segments_;
+    };
+
+    /**
+     * @brief Lightweight description of a registered command path.
+     */
+    struct CommandNode {
+        CommandPath canonical_path;
+        std::vector<CommandPath> aliases;
+    };
+
+} // namespace tonb::cad2d::shell::command
+
+#endif // TONB_CAD2D_SHELL_COMMAND_COMMAND_NODE_HXX

--- a/shell/cad2d/include/tonb/cad2d/shell/command/command_registry.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/command/command_registry.hxx
@@ -1,0 +1,65 @@
+#pragma once
+#ifndef TONB_CAD2D_SHELL_COMMAND_COMMAND_REGISTRY_HXX
+#define TONB_CAD2D_SHELL_COMMAND_COMMAND_REGISTRY_HXX
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <tonb/cad2d/shell/command/command_args.hxx>
+#include <tonb/cad2d/shell/command/command_context.hxx>
+#include <tonb/cad2d/shell/command/command_node.hxx>
+#include <tonb/cad2d/shell/module.hxx>
+
+namespace tonb::cad2d::shell::command {
+
+    using CommandHandler = std::function<CommandResult(const CommandContext&, const CommandArgs&)>;
+
+    /**
+     * @brief Resolved command-dispatch information.
+     */
+    struct CommandLookup {
+        CommandPath invoked_path;
+        CommandPath canonical_path;
+        bool used_alias = false;
+        std::size_t consumed_tokens = 0;
+    };
+
+    /**
+     * @brief Hierarchical command registry and dispatcher for the cad2d shell.
+     *
+     * The registry stores canonical command paths plus optional aliases, resolves
+     * the longest matching registered path against user tokens, and dispatches the
+     * remaining tokens to the matching command handler.
+     */
+    class CommandRegistry {
+    public:
+        TNBCAD2DSHELL_EXPORT void add_command(CommandPath path, CommandHandler handler);
+        TNBCAD2DSHELL_EXPORT void add_alias(CommandPath alias, const CommandPath& target);
+
+        TNBCAD2DSHELL_ND_EXPORT std::vector<CommandNode> nodes() const;
+        TNBCAD2DSHELL_ND_EXPORT std::vector<CommandPath> command_paths() const;
+        TNBCAD2DSHELL_ND_EXPORT std::vector<CommandPath> aliases_for(const CommandPath& canonical) const;
+
+        TNBCAD2DSHELL_ND_EXPORT std::optional<CommandLookup> resolve(const std::vector<std::string>& tokens) const;
+
+        TNBCAD2DSHELL_ND_EXPORT CommandResult dispatch(const std::vector<std::string>& tokens,
+                                                    const CommandContext& context) const;
+
+    private:
+        struct RegisteredCommand {
+            CommandHandler handler;
+        };
+
+        static std::string key_from(const CommandPath& path);
+        static bool starts_with(const std::vector<std::string>& tokens, const CommandPath& path);
+
+        std::map<CommandPath, RegisteredCommand> commands_;
+        std::map<CommandPath, CommandPath> aliases_;
+    };
+
+} // namespace tonb::cad2d::shell::command
+
+#endif // TONB_CAD2D_SHELL_COMMAND_COMMAND_REGISTRY_HXX

--- a/shell/cad2d/src/command/command_node.cxx
+++ b/shell/cad2d/src/command/command_node.cxx
@@ -1,0 +1,41 @@
+#include <sstream>
+#include <stdexcept>
+
+#include <tonb/cad2d/shell/command/command_node.hxx>
+
+namespace tonb::cad2d::shell::command {
+
+    namespace {
+        std::vector<std::string> validate_segments(std::vector<std::string> segments) {
+            if (segments.empty()) {
+                throw std::invalid_argument("command path must contain at least one segment");
+            }
+            for (const auto& segment : segments) {
+                if (segment.empty()) {
+                    throw std::invalid_argument("command path segments must not be empty");
+                }
+            }
+            return segments;
+        }
+    }
+
+    CommandPath::CommandPath(std::vector<std::string> segments)
+        : segments_(validate_segments(std::move(segments))) {
+    }
+
+    CommandPath::CommandPath(std::initializer_list<std::string> segments)
+        : segments_(validate_segments(std::vector<std::string>(segments))) {
+    }
+
+    std::string CommandPath::to_string() const {
+        std::ostringstream stream;
+        for (std::size_t i = 0; i < segments_.size(); ++i) {
+            if (i != 0) {
+                stream << ' ';
+            }
+            stream << segments_[i];
+        }
+        return stream.str();
+    }
+
+} // namespace tonb::cad2d::shell::command

--- a/shell/cad2d/src/command/command_registry.cxx
+++ b/shell/cad2d/src/command/command_registry.cxx
@@ -1,0 +1,127 @@
+#include <algorithm>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+
+#include <tonb/cad2d/shell/command/command_registry.hxx>
+
+namespace tonb::cad2d::shell::command {
+
+    void CommandRegistry::add_command(CommandPath path, CommandHandler handler) {
+        if (!handler) {
+            throw std::invalid_argument("cannot register command without handler");
+        }
+        if (commands_.contains(path)) {
+            throw std::invalid_argument("command already registered: '" + path.to_string() + "'");
+        }
+        if (aliases_.contains(path)) {
+            throw std::invalid_argument("cannot register command path already used by alias: '" + path.to_string() + "'");
+        }
+        commands_.emplace(std::move(path), RegisteredCommand{std::move(handler)});
+    }
+
+    void CommandRegistry::add_alias(CommandPath alias, const CommandPath& target) {
+        if (!commands_.contains(target)) {
+            throw std::invalid_argument("cannot register alias for missing command: '" + target.to_string() + "'");
+        }
+        if (commands_.contains(alias)) {
+            throw std::invalid_argument("cannot register alias path already used by command: '" + alias.to_string() + "'");
+        }
+        if (aliases_.contains(alias)) {
+            throw std::invalid_argument("alias already registered: '" + alias.to_string() + "'");
+        }
+        aliases_.emplace(std::move(alias), target);
+    }
+
+    std::vector<CommandNode> CommandRegistry::nodes() const {
+        std::vector<CommandNode> result;
+        result.reserve(commands_.size());
+
+        for (const auto& [path, _] : commands_) {
+            result.push_back(CommandNode{path, aliases_for(path)});
+        }
+        return result;
+    }
+
+    std::vector<CommandPath> CommandRegistry::command_paths() const {
+        std::vector<CommandPath> result;
+        result.reserve(commands_.size());
+        for (const auto& [path, _] : commands_) {
+            result.push_back(path);
+        }
+        return result;
+    }
+
+    std::vector<CommandPath> CommandRegistry::aliases_for(const CommandPath& canonical) const {
+        std::vector<CommandPath> result;
+        for (const auto& [alias, target] : aliases_) {
+            if (target == canonical) {
+                result.push_back(alias);
+            }
+        }
+        std::sort(result.begin(), result.end());
+        return result;
+    }
+
+    std::optional<CommandLookup> CommandRegistry::resolve(const std::vector<std::string>& tokens) const {
+        std::optional<CommandLookup> best;
+
+        for (const auto& [path, _] : commands_) {
+            if (starts_with(tokens, path)) {
+                const CommandLookup candidate{path, path, false, path.size()};
+                if (!best.has_value() || candidate.consumed_tokens > best->consumed_tokens) {
+                    best = candidate;
+                }
+            }
+        }
+
+        for (const auto& [alias, target] : aliases_) {
+            if (starts_with(tokens, alias)) {
+                const CommandLookup candidate{alias, target, true, alias.size()};
+                if (!best.has_value() || candidate.consumed_tokens > best->consumed_tokens) {
+                    best = candidate;
+                }
+            }
+        }
+
+        return best;
+    }
+
+    CommandResult CommandRegistry::dispatch(const std::vector<std::string>& tokens,
+                                            const CommandContext& context) const {
+        const auto lookup = resolve(tokens);
+        if (!lookup.has_value()) {
+            return CommandResult::failure("unknown command");
+        }
+
+        const auto it = commands_.find(lookup->canonical_path);
+        if (it == commands_.end()) {
+            return CommandResult::failure("resolved command has no handler: '" + lookup->canonical_path.to_string() + "'");
+        }
+
+        std::vector<std::string> remainder;
+        remainder.reserve(tokens.size() >= lookup->consumed_tokens ? tokens.size() - lookup->consumed_tokens : 0);
+        for (std::size_t i = lookup->consumed_tokens; i < tokens.size(); ++i) {
+            remainder.push_back(tokens[i]);
+        }
+
+        return it->second.handler(context, CommandArgs{std::move(remainder)});
+    }
+
+    std::string CommandRegistry::key_from(const CommandPath& path) {
+        return path.to_string();
+    }
+
+    bool CommandRegistry::starts_with(const std::vector<std::string>& tokens, const CommandPath& path) {
+        if (tokens.size() < path.size()) {
+            return false;
+        }
+        for (std::size_t i = 0; i < path.size(); ++i) {
+            if (tokens[i] != path.segments()[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+} // namespace tonb::cad2d::shell::command

--- a/tests/shell/cad2d/CMakeLists.txt
+++ b/tests/shell/cad2d/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(test_shell_cad2d_validate
         shell_session_tests.cxx
+        command_registry_tests.cxx
 )
 
 target_link_libraries(test_shell_cad2d_validate PRIVATE

--- a/tests/shell/cad2d/command_registry_tests.cxx
+++ b/tests/shell/cad2d/command_registry_tests.cxx
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include <tonb/cad2d/shell/command/command_registry.hxx>
+
+namespace {
+
+    using tonb::cad2d::shell::command::CommandContext;
+    using tonb::cad2d::shell::command::CommandPath;
+    using tonb::cad2d::shell::command::CommandRegistry;
+    using tonb::cad2d::shell::command::CommandResult;
+
+    TEST(CommandRegistryTests, DispatchesSimpleCommand) {
+        CommandRegistry registry;
+        registry.add_command(CommandPath{"ping"},
+                             [](const CommandContext&, const auto& args) {
+                                 EXPECT_TRUE(args.empty());
+                                 return CommandResult::success("pong");
+                             });
+
+        const auto result = registry.dispatch({"ping"}, CommandContext{});
+        EXPECT_TRUE(result.ok);
+        EXPECT_EQ(result.message, "pong");
+    }
+
+    TEST(CommandRegistryTests, DispatchesNestedCommandByLongestPrefix) {
+        CommandRegistry registry;
+        registry.add_command(CommandPath{"shape"},
+                             [](const CommandContext&, const auto&) {
+                                 return CommandResult::success("shape-root");
+                             });
+        registry.add_command(CommandPath{"shape", "create"},
+                             [](const CommandContext&, const auto& args) {
+                                 EXPECT_EQ(args.size(), 1u);
+                                 EXPECT_EQ(args.at(0), "S1");
+                                 return CommandResult::success("shape-create");
+                             });
+
+        const auto result = registry.dispatch({"shape", "create", "S1"}, CommandContext{});
+        EXPECT_TRUE(result.ok);
+        EXPECT_EQ(result.message, "shape-create");
+    }
+
+    TEST(CommandRegistryTests, UnknownCommandFailsCleanly) {
+        CommandRegistry registry;
+        registry.add_command(CommandPath{"ping"},
+                             [](const CommandContext&, const auto&) {
+                                 return CommandResult::success("pong");
+                             });
+
+        const auto result = registry.dispatch({"missing"}, CommandContext{});
+        EXPECT_FALSE(result.ok);
+        EXPECT_EQ(result.message, "unknown command");
+    }
+
+    TEST(CommandRegistryTests, AliasDispatchesDeterministically) {
+        CommandRegistry registry;
+        registry.add_command(CommandPath{"quit"},
+                             [](const CommandContext&, const auto&) {
+                                 return CommandResult::success("bye");
+                             });
+        registry.add_alias(CommandPath{"q"}, CommandPath{"quit"});
+
+        const auto result = registry.dispatch({"q"}, CommandContext{});
+        EXPECT_TRUE(result.ok);
+        EXPECT_EQ(result.message, "bye");
+    }
+
+    TEST(CommandRegistryTests, ConflictingAliasRegistrationIsRejected) {
+        CommandRegistry registry;
+        registry.add_command(CommandPath{"shape", "create"},
+                             [](const CommandContext&, const auto&) {
+                                 return CommandResult::success();
+                             });
+
+        EXPECT_THROW(registry.add_alias(CommandPath{"shape", "create"}, CommandPath{"shape", "create"}), std::invalid_argument);
+    }
+
+} // namespace


### PR DESCRIPTION
- implement the first real hierarchical command infrastructure for `shell/cad2d`
- add structured command path, command args, command context, command node, and command registry types
- add deterministic nested-command lookup using longest-prefix or equivalent path resolution
- add clean command-family registration through the registry
- add alias support for command-path dispatch
- add explicit unknown-command failure behavior
- add deterministic rejection of conflicting alias or command registrations
- add regression tests for simple dispatch, nested dispatch, unknown-command failure, alias dispatch, and ambiguous-registration prevention
- update the changelog under Unreleased for Issue 3 shell-command infrastructure progress