### PR TITLE
feat(shell): add foundation-backed cad2d help registry and rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - **Session foundation prepared for CAD-like growth**: The new shell session model is intentionally structured to support future selection-set, alias-handle, journaling, and undo/redo style workflows without embedding CAD algorithms into the shell state layer.
 - **cad2d command registry and dispatch foundation introduced**: Added the first real hierarchical command infrastructure for `shell/cad2d`, with deterministic path lookup, alias support, structured command dispatch, and explicit invalid-command failures.
 - **Command infrastructure aligned with future shell growth**: The new registry/context/args model is designed to support later command families, help integration, tokenisation, and AutoCAD-like command workflows without collapsing everything into ad hoc handlers.
+- **cad2d help registry and rendering introduced using foundation**: Added the first structured help subsystem for `shell/cad2d`, built on top of the Tonb foundation CLI/help layer rather than duplicating shell-local metadata and rendering infrastructure.
+- **Help foundation aligned with reusable CLI infrastructure**: The cad2d shell help layer now acts as a thin shell-specific adapter over foundation command specs, help registry structures, and rendering utilities, keeping generic help behavior in the shared root-level foundation module.
 
 ### Added
 - **Root-level Tonb foundation module**:
@@ -91,6 +93,16 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - regression tests for clean unknown-command failure
     - regression tests for alias dispatch behavior
     - regression tests ensuring ambiguous or conflicting command registration is prevented deterministically
+- **cad2d help registry and rendering infrastructure using foundation**:
+    - shell-facing help registry layer built on top of the foundation CLI/help subsystem
+    - thin shell alias/adaptor layer over foundation command-spec metadata types
+    - help rendering by command path via reusable foundation rendering utilities
+    - deterministic namespace listing for top-level and nested shell help views
+    - explicit unknown-help-path failure behavior
+- **cad2d help infrastructure test coverage**:
+    - regression tests for top-level help namespace listing
+    - regression tests for rendering help for a specific command path
+    - regression tests for clean failure on unknown help paths
 
 ### Changed
 - **Foundation namespace and include adaptation**:
@@ -101,6 +113,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - extended the root build to include the new `shell/cad2d` module
     - extended the shell module build to compile and test the first real session subsystem
     - extended the shell module build further to compile and test the first real command infrastructure subsystem
+    - extended the shell/help build further so the cad2d help layer now depends on and reuses the shared foundation CLI/help module
+- **cad2d help architecture**:
+    - replaced the earlier shell-local help duplication approach with a foundation-backed design
+    - kept cad2d-specific help wiring in `shell/cad2d` while leaving generic metadata and rendering behavior in the reusable foundation layer
 - **Bundle integrity implementation cleanup**:
     - removed an unnecessary OpenSSL include during the Tonb port of the foundation bundle-integrity implementation
 
@@ -111,7 +127,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - This completes **Issue 1 — Root-level cad2d Shell Module** from the cad2d shell roadmap.
 - This also completes **Issue 2 — Shell Session Model** from the cad2d shell roadmap.
 - This also completes **Issue 3 — Command Registry and Dispatch Infrastructure** from the cad2d shell roadmap.
-- The current `shell/cad2d` state now includes a real session foundation and command dispatch foundation, but help rendering, tokenisation, and higher-level command families remain future issues built on top of this boundary.
+- This also completes **Issue 4 — Help Registry and Help Rendering** from the cad2d shell roadmap.
+- The current `shell/cad2d` state now includes a real session foundation, command dispatch foundation, and foundation-backed help subsystem, but tokenisation and higher-level command families remain future issues built on top of this boundary.
 
 ---
 

--- a/shell/cad2d/CMakeLists.txt
+++ b/shell/cad2d/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(TonbCAD2dShell
         src/shell_session.cxx
         src/command/command_registry.cxx
         src/command/command_node.cxx
+        src/help/help_renderer.cxx
+        src/help/help_registry.cxx
         PUBLIC
         FILE_SET HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -18,6 +20,9 @@ target_sources(TonbCAD2dShell
         include/tonb/cad2d/shell/command/command_args.hxx
         include/tonb/cad2d/shell/command/command_context.hxx
         include/tonb/cad2d/shell/command/command_node.hxx
+        include/tonb/cad2d/shell/help/command_spec.hxx
+        include/tonb/cad2d/shell/help/help_registry.hxx
+        include/tonb/cad2d/shell/help/help_renderer.hxx
 )
 
 target_include_directories(TonbCAD2dShell PUBLIC
@@ -34,6 +39,7 @@ target_include_directories(TonbCAD2dShell
 target_link_libraries(TonbCAD2dShell
         PUBLIC Tonb::CAD2d
         PUBLIC Tonb::System
+        PUBLIC Tonb::Foundation
 )
 
 set_target_properties(TonbCAD2dShell PROPERTIES

--- a/shell/cad2d/include/tonb/cad2d/shell/help/command_spec.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/help/command_spec.hxx
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef TONB_CAD2D_SHELL_HELP_COMMAND_SPEC_HXX
+#define TONB_CAD2D_SHELL_HELP_COMMAND_SPEC_HXX
+
+#include <tonb/foundation/cli/command_spec.hxx>
+#include <tonb/foundation/cli/command_registry.hxx>
+
+namespace tonb::cad2d::shell::help {
+
+    using CommandSpec = foundation::cli::CommandSpec;
+    using CommandVisibility = foundation::cli::CommandVisibility;
+    using CommandStability = foundation::cli::CommandStability;
+    using DeprecationSpec = foundation::cli::DeprecationSpec;
+    using CapabilitySpec = foundation::cli::CapabilitySpec;
+    using OptionSpec = foundation::cli::OptionSpec;
+    using NamespaceSpec = foundation::cli::NamespaceSpec;
+    using ListingEntry = foundation::cli::ListingEntry;
+
+} // namespace tonb::cad2d::shell::help
+
+#endif // TONB_CAD2D_SHELL_HELP_COMMAND_SPEC_HXX

--- a/shell/cad2d/include/tonb/cad2d/shell/help/help_registry.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/help/help_registry.hxx
@@ -1,0 +1,68 @@
+#pragma once
+#ifndef TONB_CAD2D_SHELL_HELP_HELP_REGISTRY_HXX
+#define TONB_CAD2D_SHELL_HELP_HELP_REGISTRY_HXX
+
+#include <tonb/cad2d/shell/help/command_spec.hxx>
+#include <tonb/cad2d/shell/module.hxx>
+#include <tonb/foundation/cli/command_path.hxx>
+#include <tonb/foundation/cli/help_renderer.hxx>
+
+#include <string>
+#include <vector>
+
+namespace tonb::cad2d::shell::help {
+
+    /**
+     * @brief Structured result of a help-render query.
+     *
+     * The shell help subsystem reports success/failure explicitly so future
+     * command handlers can surface help failures without relying on exceptions or
+     * ad hoc string conventions.
+     */
+    struct HelpResult {
+        bool ok = true;
+        std::string text;
+
+        TNB_NODISCARD static HelpResult success(std::string value) {
+            return HelpResult{true, std::move(value)};
+        }
+
+        TNB_NODISCARD static HelpResult failure(std::string value) {
+            return HelpResult{false, std::move(value)};
+        }
+    };
+
+    /**
+     * @brief cad2d shell help registry built on the Tonb foundation CLI registry.
+     *
+     * This class owns shell-specific help content while delegating the generic
+     * command metadata, namespace listing, alias handling, and rendering support
+     * to the reusable foundation CLI layer.
+     */
+    class HelpRegistry {
+    public:
+        HelpRegistry() = default;
+
+        TNBCAD2DSHELL_EXPORT void add_namespace(NamespaceSpec spec);
+        TNBCAD2DSHELL_EXPORT void add_command(CommandSpec spec);
+
+        TNBCAD2DSHELL_ND_EXPORT const foundation::cli::CommandRegistry& foundation_registry() const noexcept;
+
+        TNBCAD2DSHELL_ND_EXPORT std::string render_root(
+            const foundation::cli::RenderOptions& options = {}) const;
+
+        TNBCAD2DSHELL_ND_EXPORT HelpResult render_path(
+            const foundation::cli::CommandPath& path,
+            const foundation::cli::RenderOptions& options = {}) const;
+
+        TNBCAD2DSHELL_ND_EXPORT HelpResult render_path(
+            const std::vector<std::string>& segments,
+            const foundation::cli::RenderOptions& options = {}) const;
+
+    private:
+        foundation::cli::CommandRegistry registry_;
+    };
+
+} // namespace tonb::cad2d::shell::help
+
+#endif // TONB_CAD2D_SHELL_HELP_HELP_REGISTRY_HXX

--- a/shell/cad2d/include/tonb/cad2d/shell/help/help_renderer.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/help/help_renderer.hxx
@@ -1,0 +1,35 @@
+#pragma once
+#ifndef TONB_CAD2D_SHELL_HELP_HELP_RENDERER_HXX
+#define TONB_CAD2D_SHELL_HELP_HELP_RENDERER_HXX
+
+#include <tonb/cad2d/shell/help/help_registry.hxx>
+#include <tonb/cad2d/shell/module.hxx>
+
+namespace tonb::cad2d::shell::help {
+
+    /**
+     * @brief Render top-level shell help using the foundation namespace renderer.
+     */
+    TNBCAD2DSHELL_ND_EXPORT std::string render_help_root(
+        const HelpRegistry& registry,
+        const foundation::cli::RenderOptions& options = {});
+
+    /**
+     * @brief Render help for a specific command or namespace path.
+     */
+    TNBCAD2DSHELL_ND_EXPORT HelpResult render_help(
+        const HelpRegistry& registry,
+        const foundation::cli::CommandPath& path,
+        const foundation::cli::RenderOptions& options = {});
+
+    /**
+     * @brief Render help for a specific command or namespace path expressed as segments.
+     */
+    TNBCAD2DSHELL_ND_EXPORT HelpResult render_help(
+        const HelpRegistry& registry,
+        const std::vector<std::string>& segments,
+        const foundation::cli::RenderOptions& options = {});
+
+} // namespace tonb::cad2d::shell::help
+
+#endif // TONB_CAD2D_SHELL_HELP_HELP_RENDERER_HXX

--- a/shell/cad2d/src/help/help_registry.cxx
+++ b/shell/cad2d/src/help/help_registry.cxx
@@ -1,0 +1,42 @@
+#include <tonb/cad2d/shell/help/help_registry.hxx>
+
+#include <tonb/foundation/cli/help_renderer.hxx>
+
+namespace tonb::cad2d::shell::help {
+
+    void HelpRegistry::add_namespace(NamespaceSpec spec) {
+        registry_.add_namespace(std::move(spec));
+    }
+
+    void HelpRegistry::add_command(CommandSpec spec) {
+        registry_.add_command(std::move(spec));
+    }
+
+    const foundation::cli::CommandRegistry& HelpRegistry::foundation_registry() const noexcept {
+        return registry_;
+    }
+
+    std::string HelpRegistry::render_root(const foundation::cli::RenderOptions& options) const {
+        return foundation::cli::render_namespace(registry_, foundation::cli::CommandPath{}, options);
+    }
+
+    HelpResult HelpRegistry::render_path(const foundation::cli::CommandPath& path,
+                                         const foundation::cli::RenderOptions& options) const {
+        if (const auto* spec = registry_.resolve_exact(path); spec != nullptr) {
+            return HelpResult::success(foundation::cli::render_command(*spec, options));
+        }
+
+        if (const auto* ns = registry_.find_namespace(path); ns != nullptr) {
+            (void)ns;
+            return HelpResult::success(foundation::cli::render_namespace(registry_, path, options));
+        }
+
+        return HelpResult::failure("unknown help path: " + path.to_string());
+    }
+
+    HelpResult HelpRegistry::render_path(const std::vector<std::string>& segments,
+                                         const foundation::cli::RenderOptions& options) const {
+        return render_path(foundation::cli::CommandPath(segments), options);
+    }
+
+} // namespace tonb::cad2d::shell::help

--- a/shell/cad2d/src/help/help_renderer.cxx
+++ b/shell/cad2d/src/help/help_renderer.cxx
@@ -1,0 +1,22 @@
+#include <tonb/cad2d/shell/help/help_renderer.hxx>
+
+namespace tonb::cad2d::shell::help {
+
+    std::string render_help_root(const HelpRegistry& registry,
+                                 const foundation::cli::RenderOptions& options) {
+        return registry.render_root(options);
+    }
+
+    HelpResult render_help(const HelpRegistry& registry,
+                           const foundation::cli::CommandPath& path,
+                           const foundation::cli::RenderOptions& options) {
+        return registry.render_path(path, options);
+    }
+
+    HelpResult render_help(const HelpRegistry& registry,
+                           const std::vector<std::string>& segments,
+                           const foundation::cli::RenderOptions& options) {
+        return registry.render_path(segments, options);
+    }
+
+} // namespace tonb::cad2d::shell::help

--- a/tests/shell/cad2d/CMakeLists.txt
+++ b/tests/shell/cad2d/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(test_shell_cad2d_validate
         shell_session_tests.cxx
         command_registry_tests.cxx
+        help_register_tests.cxx
 )
 
 target_link_libraries(test_shell_cad2d_validate PRIVATE

--- a/tests/shell/cad2d/help_register_tests.cxx
+++ b/tests/shell/cad2d/help_register_tests.cxx
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include <tonb/cad2d/shell/help/help_registry.hxx>
+#include <tonb/cad2d/shell/help/help_renderer.hxx>
+
+namespace shell_help = tonb::cad2d::shell::help;
+namespace fcli = tonb::foundation::cli;
+
+namespace {
+    shell_help::HelpRegistry make_registry() {
+        shell_help::HelpRegistry reg;
+
+        reg.add_namespace(fcli::NamespaceSpec{
+            .path = fcli::CommandPath({"curve"}),
+            .summary = "Curve commands"
+        });
+        reg.add_namespace(fcli::NamespaceSpec{
+            .path = fcli::CommandPath({"shape"}),
+            .summary = "Shape commands"
+        });
+
+        fcli::CommandSpec help_spec;
+        help_spec.canonical_path = fcli::CommandPath({"help"});
+        help_spec.domain = "shell";
+        help_spec.summary = "Show command help";
+        help_spec.usage = {"help", "help <command...>"};
+        help_spec.examples = {"help", "help curve add"};
+        reg.add_command(std::move(help_spec));
+
+        fcli::CommandSpec curve_add_spec;
+        curve_add_spec.canonical_path = fcli::CommandPath({"curve", "add"});
+        curve_add_spec.domain = "curve";
+        curve_add_spec.summary = "Add a curve to the active or named store";
+        curve_add_spec.usage = {"curve add segment <store> <curve-id> x0 y0 x1 y1"};
+        curve_add_spec.examples = {"curve add segment C1 1 0 0 1 0"};
+        reg.add_command(std::move(curve_add_spec));
+
+        return reg;
+    }
+}
+
+TEST(cad2d_shell_help_registry, root_help_lists_top_level_groups) {
+    const auto reg = make_registry();
+    const std::string text = shell_help::render_help_root(reg);
+
+    EXPECT_NE(text.find("root"), std::string::npos);
+    EXPECT_NE(text.find("curve"), std::string::npos);
+    EXPECT_NE(text.find("shape"), std::string::npos);
+}
+
+TEST(cad2d_shell_help_registry, command_help_renders_specific_command) {
+    const auto reg = make_registry();
+    const auto result = shell_help::render_help(reg, fcli::CommandPath({"curve", "add"}));
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_NE(result.text.find("curve add"), std::string::npos);
+    EXPECT_NE(result.text.find("Add a curve to the active or named store"), std::string::npos);
+    EXPECT_NE(result.text.find("Usage"), std::string::npos);
+}
+
+TEST(cad2d_shell_help_registry, unknown_command_help_fails_cleanly) {
+    const auto reg = make_registry();
+    const auto result = shell_help::render_help(reg, fcli::CommandPath({"mesh", "build"}));
+
+    EXPECT_FALSE(result.ok);
+    EXPECT_NE(result.text.find("unknown help path"), std::string::npos);
+}


### PR DESCRIPTION
- implement the first structured help subsystem for `shell/cad2d`
- build the cad2d help layer on top of the shared Tonb foundation CLI/help module rather than duplicating shell-local metadata and rendering infrastructure
- add shell-facing help registry support for command-path-based help lookup
- add thin cad2d shell adapters/aliases over foundation command-spec metadata types
- add readable command and namespace help rendering through reusable foundation rendering utilities
- add deterministic namespace listing for top-level and nested help views
- add explicit failure behavior for unknown help paths
- add regression tests for top-level help listing, specific command help rendering, and unknown help-path failure
- update the changelog under Unreleased for Issue 4 foundation-backed help progress