### PR TITLE
feat(shell): add foundation-backed cad2d tokenisation and parse utili…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - **Command infrastructure aligned with future shell growth**: The new registry/context/args model is designed to support later command families, help integration, tokenisation, and AutoCAD-like command workflows without collapsing everything into ad hoc handlers.
 - **cad2d help registry and rendering introduced using foundation**: Added the first structured help subsystem for `shell/cad2d`, built on top of the Tonb foundation CLI/help layer rather than duplicating shell-local metadata and rendering infrastructure.
 - **Help foundation aligned with reusable CLI infrastructure**: The cad2d shell help layer now acts as a thin shell-specific adapter over foundation command specs, help registry structures, and rendering utilities, keeping generic help behavior in the shared root-level foundation module.
+- **cad2d tokenisation and parse utilities introduced using foundation**: Added the first shell-specific command-line tokenisation layer for `shell/cad2d`, with deterministic whitespace tokenisation, quoted-string preservation, explicit malformed-input failure, and positional parsing helpers built on top of the shared foundation parse utilities.
+- **Tokenisation foundation aligned with reusable parse infrastructure**: The cad2d shell now reuses the shared foundation scalar parse functions for strict positional argument conversion, while keeping command-line token splitting and positional argument views in the shell layer.
 
 ### Added
 - **Root-level Tonb foundation module**:
@@ -103,6 +105,17 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - regression tests for top-level help namespace listing
     - regression tests for rendering help for a specific command path
     - regression tests for clean failure on unknown help paths
+- **cad2d tokenisation and parse utilities using foundation**:
+    - shell-specific whitespace tokenisation for command-line input
+    - quoted-string preservation using shell tokenisation rules
+    - explicit malformed-quote failure behavior
+    - lightweight positional-argument view for straightforward shell argument handling
+    - strict scalar positional parsing delegated to foundation CLI parse utilities
+- **cad2d tokenisation test coverage**:
+    - regression tests for simple command tokenisation
+    - regression tests for preserving quoted tokens intact
+    - regression tests for clean failure on malformed quoted input
+    - regression tests for positional parsing helper behavior
 
 ### Changed
 - **Foundation namespace and include adaptation**:
@@ -114,9 +127,13 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - extended the shell module build to compile and test the first real session subsystem
     - extended the shell module build further to compile and test the first real command infrastructure subsystem
     - extended the shell/help build further so the cad2d help layer now depends on and reuses the shared foundation CLI/help module
+    - extended the shell/tokenisation build further so the cad2d tokenisation layer now depends on and reuses the shared foundation CLI parse utilities
 - **cad2d help architecture**:
     - replaced the earlier shell-local help duplication approach with a foundation-backed design
     - kept cad2d-specific help wiring in `shell/cad2d` while leaving generic metadata and rendering behavior in the reusable foundation layer
+- **cad2d tokenisation architecture**:
+    - kept shell-specific token splitting and positional-argument views in `shell/cad2d`
+    - reused foundation scalar parsing rather than duplicating integer, floating-point, and boolean parse helpers inside the shell layer
 - **Bundle integrity implementation cleanup**:
     - removed an unnecessary OpenSSL include during the Tonb port of the foundation bundle-integrity implementation
 
@@ -128,7 +145,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - This also completes **Issue 2 — Shell Session Model** from the cad2d shell roadmap.
 - This also completes **Issue 3 — Command Registry and Dispatch Infrastructure** from the cad2d shell roadmap.
 - This also completes **Issue 4 — Help Registry and Help Rendering** from the cad2d shell roadmap.
-- The current `shell/cad2d` state now includes a real session foundation, command dispatch foundation, and foundation-backed help subsystem, but tokenisation and higher-level command families remain future issues built on top of this boundary.
+- This also completes **Issue 5 — Tokenisation and Parse Utilities** from the cad2d shell roadmap.
+- The current `shell/cad2d` state now includes a real session foundation, command dispatch foundation, foundation-backed help subsystem, and foundation-backed tokenisation/parse layer, but higher-level command families remain future issues built on top of this boundary.
 
 ---
 

--- a/shell/cad2d/CMakeLists.txt
+++ b/shell/cad2d/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(TonbCAD2dShell
         PRIVATE
         src/shell_app.cxx
         src/shell_session.cxx
+        src/shell_tokenise.cxx
         src/command/command_registry.cxx
         src/command/command_node.cxx
         src/help/help_renderer.cxx
@@ -16,6 +17,7 @@ target_sources(TonbCAD2dShell
         include/tonb/cad2d/shell/module.hxx
         include/tonb/cad2d/shell/shell_app.hxx
         include/tonb/cad2d/shell/shell_session.hxx
+        include/tonb/cad2d/shell/shell_tokenise.hxx
         include/tonb/cad2d/shell/command/command_registry.hxx
         include/tonb/cad2d/shell/command/command_args.hxx
         include/tonb/cad2d/shell/command/command_context.hxx

--- a/shell/cad2d/include/tonb/cad2d/shell/shell_tokenise.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/shell_tokenise.hxx
@@ -1,8 +1,73 @@
-//
-// Created by amir on 5/8/26.
-//
+/**
+ * @file shell_tokenise.hxx
+ * @brief Shell command-line tokenisation and positional parse helpers for cad2d shell.
+ *
+ * @details
+ * This layer provides shell-specific command-line tokenisation on top of the shared
+ * Tonb foundation CLI parsing helpers. Generic scalar parsing remains in
+ * `tonb::foundation::cli::parse_utils`, while this module handles shell command-line
+ * concerns such as whitespace splitting, quoted tokens, and positional argument access.
+ */
+#pragma once
+#ifndef TONB_CAD2D_SHELL_SHELL_TOKENISE_HXX
+#define TONB_CAD2D_SHELL_SHELL_TOKENISE_HXX
 
-#ifndef TONB_SHELL_TOKENISE_HXX
-#define TONB_SHELL_TOKENISE_HXX
+#include <tonb/cad2d/shell/module.hxx>
+#include <tonb/foundation/cli/parse_utils.hxx>
 
-#endif //TONB_SHELL_TOKENISE_HXX
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace tonb::cad2d::shell {
+
+    /**
+     * @brief Result of tokenising one shell command line.
+     */
+    struct TokeniseResult {
+        bool ok = true;
+        std::vector<std::string> tokens;
+        std::string error;
+    };
+
+    /**
+     * @brief Tokenise one shell command line.
+     *
+     * @details
+     * The tokenizer performs whitespace-based splitting while preserving quoted strings
+     * as single tokens. Double quotes are supported. A malformed unterminated quote
+     * produces an explicit failure.
+     */
+    TNBCAD2DSHELL_ND_EXPORT TokeniseResult tokenise_command_line(std::string_view line);
+
+    /**
+     * @brief Lightweight positional argument view for token vectors.
+     *
+     * @details
+     * This helper is intentionally simple and intended for shell command handlers after
+     * command dispatch has already identified the command path. Scalar conversion is
+     * delegated to the shared foundation CLI parse helpers.
+     */
+    class PositionalArgsView {
+    public:
+        explicit TNBCAD2DSHELL_EXPORT PositionalArgsView(const std::vector<std::string>& tokens) noexcept;
+
+        TNBCAD2DSHELL_ND_EXPORT std::size_t size() const noexcept;
+        TNBCAD2DSHELL_ND_EXPORT bool has(std::size_t index) const noexcept;
+        TNBCAD2DSHELL_ND_EXPORT std::optional<std::string_view> get(std::size_t index) const noexcept;
+
+        TNBCAD2DSHELL_ND_EXPORT std::string_view require(std::size_t index, std::string_view label) const;
+        TNBCAD2DSHELL_ND_EXPORT int parse_int(std::size_t index, std::string_view label) const;
+        TNBCAD2DSHELL_ND_EXPORT long long parse_long_long(std::size_t index, std::string_view label) const;
+        TNBCAD2DSHELL_ND_EXPORT double parse_double(std::size_t index, std::string_view label) const;
+        TNBCAD2DSHELL_ND_EXPORT bool parse_bool(std::size_t index, std::string_view label) const;
+
+    private:
+        const std::vector<std::string>* tokens_ = nullptr;
+    };
+
+} // namespace tonb::cad2d::shell
+
+#endif // TONB_CAD2D_SHELL_SHELL_TOKENISE_HXX

--- a/shell/cad2d/src/shell_tokenise.cxx
+++ b/shell/cad2d/src/shell_tokenise.cxx
@@ -1,0 +1,88 @@
+/**
+ * @file shell_tokenise.cxx
+ * @brief Implementation of shell command-line tokenisation and positional parse helpers.
+ */
+#include <tonb/cad2d/shell/shell_tokenise.hxx>
+
+#include <stdexcept>
+
+namespace tonb::cad2d::shell {
+
+    TokeniseResult tokenise_command_line(const std::string_view line) {
+        TokeniseResult result{};
+        std::string current;
+        bool in_quotes = false;
+
+        auto flush_current = [&]() {
+            if (!current.empty()) {
+                result.tokens.push_back(current);
+                current.clear();
+            }
+        };
+
+        for (char ch : line) {
+            if (ch == '"') {
+                in_quotes = !in_quotes;
+                continue;
+            }
+
+            if (!in_quotes && (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r')) {
+                flush_current();
+                continue;
+            }
+
+            current.push_back(ch);
+        }
+
+        if (in_quotes) {
+            result.ok = false;
+            result.tokens.clear();
+            result.error = "tokenise_command_line: unterminated quoted string";
+            return result;
+        }
+
+        flush_current();
+        return result;
+    }
+
+    PositionalArgsView::PositionalArgsView(const std::vector<std::string>& tokens) noexcept
+        : tokens_(&tokens) {
+    }
+
+    std::size_t PositionalArgsView::size() const noexcept {
+        return tokens_ ? tokens_->size() : 0u;
+    }
+
+    bool PositionalArgsView::has(const std::size_t index) const noexcept {
+        return tokens_ && index < tokens_->size();
+    }
+
+    std::optional<std::string_view> PositionalArgsView::get(const std::size_t index) const noexcept {
+        if (!has(index)) return std::nullopt;
+        return std::string_view((*tokens_)[index]);
+    }
+
+    std::string_view PositionalArgsView::require(const std::size_t index, const std::string_view label) const {
+        if (const auto value = get(index)) {
+            return *value;
+        }
+        throw std::invalid_argument(std::string("PositionalArgsView::require: missing argument: ") + std::string(label));
+    }
+
+    int PositionalArgsView::parse_int(const std::size_t index, const std::string_view label) const {
+        return foundation::cli::parse_int_strict(require(index, label));
+    }
+
+    long long PositionalArgsView::parse_long_long(const std::size_t index, const std::string_view label) const {
+        return foundation::cli::parse_long_long_strict(require(index, label));
+    }
+
+    double PositionalArgsView::parse_double(const std::size_t index, const std::string_view label) const {
+        return foundation::cli::parse_double_strict(require(index, label));
+    }
+
+    bool PositionalArgsView::parse_bool(const std::size_t index, const std::string_view label) const {
+        return foundation::cli::parse_bool_strict(require(index, label));
+    }
+
+} // namespace tonb::cad2d::shell

--- a/tests/shell/cad2d/CMakeLists.txt
+++ b/tests/shell/cad2d/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(test_shell_cad2d_validate
         shell_session_tests.cxx
         command_registry_tests.cxx
         help_register_tests.cxx
+        shell_tokenise_tests.cxx
 )
 
 target_link_libraries(test_shell_cad2d_validate PRIVATE

--- a/tests/shell/cad2d/shell_tokenise_tests.cxx
+++ b/tests/shell/cad2d/shell_tokenise_tests.cxx
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include <tonb/cad2d/shell/shell_tokenise.hxx>
+
+namespace {
+
+    using tonb::cad2d::shell::PositionalArgsView;
+    using tonb::cad2d::shell::tokenise_command_line;
+
+    TEST(ShellTokeniseTests, SimpleCommandTokenisesCorrectly) {
+        const auto result = tokenise_command_line("shape create S1");
+        ASSERT_TRUE(result.ok);
+        ASSERT_EQ(result.tokens.size(), 3u);
+        EXPECT_EQ(result.tokens[0], "shape");
+        EXPECT_EQ(result.tokens[1], "create");
+        EXPECT_EQ(result.tokens[2], "S1");
+    }
+
+    TEST(ShellTokeniseTests, QuotedTokenRemainsIntact) {
+        const auto result = tokenise_command_line("shape create \"main shape\"");
+        ASSERT_TRUE(result.ok);
+        ASSERT_EQ(result.tokens.size(), 3u);
+        EXPECT_EQ(result.tokens[2], "main shape");
+    }
+
+    TEST(ShellTokeniseTests, UnterminatedQuoteFailsCleanly) {
+        const auto result = tokenise_command_line("shape create \"main shape");
+        EXPECT_FALSE(result.ok);
+        EXPECT_TRUE(result.tokens.empty());
+        EXPECT_FALSE(result.error.empty());
+    }
+
+    TEST(ShellTokeniseTests, PositionalParseHelpersWorkDeterministically) {
+        const auto result = tokenise_command_line("set count 42 3.5 yes");
+        ASSERT_TRUE(result.ok);
+        PositionalArgsView args(result.tokens);
+        EXPECT_EQ(args.require(0, "command"), "set");
+        EXPECT_EQ(args.parse_int(2, "count"), 42);
+        EXPECT_DOUBLE_EQ(args.parse_double(3, "value"), 3.5);
+        EXPECT_TRUE(args.parse_bool(4, "flag"));
+    }
+
+} // namespace


### PR DESCRIPTION
…ties

- implement the first shell-specific command-line tokenisation layer for `shell/cad2d`
- add deterministic whitespace tokenisation for shell input
- add quoted-string preservation using shell tokenisation rules
- add explicit malformed-quote failure behavior
- add a lightweight positional-argument view for straightforward shell argument handling
- reuse the shared foundation CLI parse utilities for strict scalar positional parsing instead of duplicating integer, floating-point, and boolean parse helpers in the shell layer
- keep shell-specific token splitting and positional argument views in `shell/cad2d` while delegating generic scalar parsing to the root-level foundation module
- add regression tests for simple tokenisation, quoted-token preservation, malformed quoted-input failure, and positional parsing behavior
- update the changelog under Unreleased for Issue 5 foundation-backed tokenisation and parse progress