### PR TITLE
feat(shell): add core cad2d shell commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - **Help foundation aligned with reusable CLI infrastructure**: The cad2d shell help layer now acts as a thin shell-specific adapter over foundation command specs, help registry structures, and rendering utilities, keeping generic help behavior in the shared root-level foundation module.
 - **cad2d tokenisation and parse utilities introduced using foundation**: Added the first shell-specific command-line tokenisation layer for `shell/cad2d`, with deterministic whitespace tokenisation, quoted-string preservation, explicit malformed-input failure, and positional parsing helpers built on top of the shared foundation parse utilities.
 - **Tokenisation foundation aligned with reusable parse infrastructure**: The cad2d shell now reuses the shared foundation scalar parse functions for strict positional argument conversion, while keeping command-line token splitting and positional argument views in the shell layer.
+- **cad2d core shell commands introduced**: Added the first real user-facing core command family for `shell/cad2d`, including `help`, `status`, `reset`, `quit`, and `exit`, routed through the command registry and backed by the session, help, and tokenisation foundations.
+- **Core command flow established for future shell features**: The shell now has a minimal but complete command execution loop foundation, with structured dispatch, readable status reporting, deterministic reset behavior, clean runtime termination control, and a real command family on top of the previously completed infrastructure layers.
 
 ### Added
 - **Root-level Tonb foundation module**:
@@ -116,6 +118,18 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - regression tests for preserving quoted tokens intact
     - regression tests for clean failure on malformed quoted input
     - regression tests for positional parsing helper behavior
+- **cad2d core shell commands**:
+    - first real shell command family for `help`, `status`, `reset`, `quit`, and `exit`
+    - structured command registration for core shell commands through the command registry
+    - `status` command reporting deterministic session state
+    - `reset` command clearing session state deterministically
+    - `quit` and `exit` commands setting runtime termination state cleanly
+    - `help` command integration over the foundation-backed help subsystem
+- **cad2d core command test coverage**:
+    - regression tests for `status` on an empty session
+    - regression tests for deterministic session clearing through `reset`
+    - regression tests for clean runtime termination flag handling through `quit` and `exit`
+    - regression tests for `help` command execution through the command registry
 
 ### Changed
 - **Foundation namespace and include adaptation**:
@@ -128,12 +142,16 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
     - extended the shell module build further to compile and test the first real command infrastructure subsystem
     - extended the shell/help build further so the cad2d help layer now depends on and reuses the shared foundation CLI/help module
     - extended the shell/tokenisation build further so the cad2d tokenisation layer now depends on and reuses the shared foundation CLI parse utilities
+    - extended the shell/commands build further so the first real core command family is now built and tested through the command registry infrastructure
 - **cad2d help architecture**:
     - replaced the earlier shell-local help duplication approach with a foundation-backed design
     - kept cad2d-specific help wiring in `shell/cad2d` while leaving generic metadata and rendering behavior in the reusable foundation layer
 - **cad2d tokenisation architecture**:
     - kept shell-specific token splitting and positional-argument views in `shell/cad2d`
     - reused foundation scalar parsing rather than duplicating integer, floating-point, and boolean parse helpers inside the shell layer
+- **cad2d shell execution flow**:
+    - moved the shell from infrastructure-only state to the first real command-executing state by adding a core command family that composes session state, command dispatch, help rendering, and tokenisation utilities
+    - corrected core-command help registration to avoid invalid empty root-namespace insertion against the foundation command registry
 - **Bundle integrity implementation cleanup**:
     - removed an unnecessary OpenSSL include during the Tonb port of the foundation bundle-integrity implementation
 
@@ -146,7 +164,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - This also completes **Issue 3 — Command Registry and Dispatch Infrastructure** from the cad2d shell roadmap.
 - This also completes **Issue 4 — Help Registry and Help Rendering** from the cad2d shell roadmap.
 - This also completes **Issue 5 — Tokenisation and Parse Utilities** from the cad2d shell roadmap.
-- The current `shell/cad2d` state now includes a real session foundation, command dispatch foundation, foundation-backed help subsystem, and foundation-backed tokenisation/parse layer, but higher-level command families remain future issues built on top of this boundary.
+- This also completes **Issue 6 — Core Shell Commands** from the cad2d shell roadmap.
+- The current `shell/cad2d` state now includes a real session foundation, command dispatch foundation, foundation-backed help subsystem, foundation-backed tokenisation/parse layer, and the first real core command family. Higher-level domain command families remain future issues built on top of this boundary.
 
 ---
 

--- a/shell/cad2d/CMakeLists.txt
+++ b/shell/cad2d/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(TonbCAD2dShell
         src/shell_tokenise.cxx
         src/command/command_registry.cxx
         src/command/command_node.cxx
+        src/commands/shell_cmd_core.cxx
         src/help/help_renderer.cxx
         src/help/help_registry.cxx
         PUBLIC
@@ -22,6 +23,7 @@ target_sources(TonbCAD2dShell
         include/tonb/cad2d/shell/command/command_args.hxx
         include/tonb/cad2d/shell/command/command_context.hxx
         include/tonb/cad2d/shell/command/command_node.hxx
+        include/tonb/cad2d/shell/commands/shell_cmd_core.hxx
         include/tonb/cad2d/shell/help/command_spec.hxx
         include/tonb/cad2d/shell/help/help_registry.hxx
         include/tonb/cad2d/shell/help/help_renderer.hxx

--- a/shell/cad2d/include/tonb/cad2d/shell/commands/shell_cmd_core.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/commands/shell_cmd_core.hxx
@@ -1,0 +1,24 @@
+#pragma once
+#ifndef TONB_CAD2D_SHELL_COMMANDS_SHELL_CMD_CORE_HXX
+#define TONB_CAD2D_SHELL_COMMANDS_SHELL_CMD_CORE_HXX
+
+#include <tonb/cad2d/shell/command/command_registry.hxx>
+#include <tonb/cad2d/shell/help/help_registry.hxx>
+#include <tonb/cad2d/shell/module.hxx>
+
+namespace tonb::cad2d::shell::commands {
+
+/**
+ * @brief Register the core shell commands and their help metadata.
+ *
+ * @details
+ * This family provides the first user-facing shell commands: `help`, `status`,
+ * `reset`, `quit`, and `exit`.
+ */
+TNBCAD2DSHELL_EXPORT void register_core_commands(
+    command::CommandRegistry& commands,
+    help::HelpRegistry& help);
+
+} // namespace tonb::cad2d::shell::commands
+
+#endif // TONB_CAD2D_SHELL_COMMANDS_SHELL_CMD_CORE_HXX

--- a/shell/cad2d/include/tonb/cad2d/shell/shell_app.hxx
+++ b/shell/cad2d/include/tonb/cad2d/shell/shell_app.hxx
@@ -2,35 +2,67 @@
 #ifndef TONB_CAD2D_SHELL_SHELL_APP_HXX
 #define TONB_CAD2D_SHELL_SHELL_APP_HXX
 
+#include <iosfwd>
+#include <string>
 #include <string_view>
+#include <vector>
 
+#include <tonb/cad2d/shell/command/command_args.hxx>
+#include <tonb/cad2d/shell/command/command_registry.hxx>
+#include <tonb/cad2d/shell/help/help_registry.hxx>
 #include <tonb/cad2d/shell/module.hxx>
+#include <tonb/cad2d/shell/shell_session.hxx>
 
 namespace tonb::cad2d::shell {
 
+/**
+ * @brief Public façade for the cad2d shell runtime.
+ *
+ * @details
+ * The shell app owns the shell session plus the command and help registries.
+ * It provides a minimal execution entry point for tokenised or line-based
+ * shell commands while keeping the higher-level CAD logic in dedicated command
+ * handlers.
+ */
+class TNBCAD2DSHELL_EXPORT ShellApp {
+public:
+    ShellApp();
+
+    [[nodiscard]] static std::string_view module_name() noexcept;
+    [[nodiscard]] bool has_foundation_support() const noexcept;
+
+    [[nodiscard]] command::CommandRegistry& commands() noexcept;
+    [[nodiscard]] const command::CommandRegistry& commands() const noexcept;
+
+    [[nodiscard]] help::HelpRegistry& help() noexcept;
+    [[nodiscard]] const help::HelpRegistry& help() const noexcept;
+
+    [[nodiscard]] ShellSession& session() noexcept;
+    [[nodiscard]] const ShellSession& session() const noexcept;
+
     /**
-     * @brief Minimal public façade for the cad2d shell module.
-     *
-     * Issue 1 only establishes the root-level shell module, its public include
-     * layout, and its build integration. Higher-level shell runtime features such
-     * as session state, command dispatch, help registries, and CAD workflows are
-     * intentionally deferred to later issues.
+     * @brief Execute one already-tokenised shell command.
      */
-    class ShellApp {
-    public:
-        ShellApp() = default;
+    TNBCAD2DSHELL_ND_EXPORT command::CommandResult execute_tokens(
+        const std::vector<std::string>& tokens,
+        std::ostream* out = nullptr,
+        std::ostream* err = nullptr);
 
-        /**
-         * @brief Return the public module name for the cad2d shell library.
-         */
-        static TNBCAD2DSHELL_EXPORT std::string_view module_name() noexcept;
+    /**
+     * @brief Tokenise and execute one shell command line.
+     */
+    TNBCAD2DSHELL_ND_EXPORT command::CommandResult execute_line(
+        std::string_view line,
+        std::ostream* out = nullptr,
+        std::ostream* err = nullptr);
 
-        /**
-         * @brief Report whether the shell was built with the Tonb foundation layer
-         * available as a linked dependency.
-         */
-        static TNBCAD2DSHELL_EXPORT bool has_foundation_support() noexcept;
-    };
+private:
+    void register_core_commands_();
+
+    ShellSession session_;
+    command::CommandRegistry commands_;
+    help::HelpRegistry help_;
+};
 
 } // namespace tonb::cad2d::shell
 

--- a/shell/cad2d/src/commands/shell_cmd_core.cxx
+++ b/shell/cad2d/src/commands/shell_cmd_core.cxx
@@ -1,0 +1,135 @@
+#include <tonb/cad2d/shell/commands/shell_cmd_core.hxx>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <tonb/cad2d/shell/command/command_context.hxx>
+#include <tonb/cad2d/shell/help/help_renderer.hxx>
+#include <tonb/cad2d/shell/shell_session.hxx>
+#include <tonb/foundation/cli/command_path.hxx>
+#include <tonb/foundation/cli/help_renderer.hxx>
+
+namespace tonb::cad2d::shell::commands {
+    namespace {
+
+        using command::CommandArgs;
+        using command::CommandContext;
+        using command::CommandResult;
+
+        std::string render_status_text(const ShellSession& session) {
+            const auto st = session.status();
+
+            std::ostringstream out;
+            out << "curve stores: " << st.curve_store_count << '\n';
+            out << "active curve store: " << (st.active_curve_store ? *st.active_curve_store : std::string{"<none>"}) << '\n';
+            out << "shapes: " << st.shape_count << '\n';
+            out << "active shape: " << (st.active_shape ? *st.active_shape : std::string{"<none>"}) << '\n';
+            out << "active shape curve store: "
+                << (st.active_shape_curve_store ? *st.active_shape_curve_store : std::string{"<none>"}) << '\n';
+            out << "primary selection: ";
+            if (st.primary_selection) {
+                out << st.primary_selection->shape_name << ':' << static_cast<int>(st.primary_selection->kind) << ':' << st.primary_selection->id;
+            } else {
+                out << "<none>";
+            }
+            out << '\n';
+            out << "exit requested: " << (st.runtime.exit_requested ? "true" : "false") << '\n';
+            out << "verbose: " << (st.runtime.verbose ? "true" : "false") << '\n';
+            out << "echo commands: " << (st.runtime.echo_commands ? "true" : "false");
+            return out.str();
+        }
+
+        CommandResult cmd_status(const CommandContext& context, const CommandArgs& args) {
+            if (!args.empty()) {
+                return CommandResult::failure("status: unexpected arguments");
+            }
+            if (context.session() == nullptr) {
+                return CommandResult::failure("status: missing shell session");
+            }
+            return CommandResult::success(render_status_text(*context.session()));
+        }
+
+        CommandResult cmd_reset(const CommandContext& context, const CommandArgs& args) {
+            if (!args.empty()) {
+                return CommandResult::failure("reset: unexpected arguments");
+            }
+            if (context.session() == nullptr) {
+                return CommandResult::failure("reset: missing shell session");
+            }
+            context.session()->reset();
+            return CommandResult::success("session reset");
+        }
+
+        CommandResult cmd_quit(const CommandContext& context, const CommandArgs& args) {
+            if (!args.empty()) {
+                return CommandResult::failure("quit: unexpected arguments");
+            }
+            if (context.session() == nullptr) {
+                return CommandResult::failure("quit: missing shell session");
+            }
+            context.session()->runtime().exit_requested = true;
+            return CommandResult::success("exit requested");
+        }
+
+    } // namespace
+
+    void register_core_commands(command::CommandRegistry& commands,
+                                help::HelpRegistry& help_registry) {
+        using foundation::cli::CommandPath;
+        using help::CommandSpec;
+
+        commands.add_command(command::CommandPath{"help"},
+            [&help_registry](const CommandContext&, const CommandArgs& args) -> CommandResult {
+                foundation::cli::RenderOptions options{};
+                if (args.empty()) {
+                    return CommandResult::success(help::render_help_root(help_registry, options));
+                }
+                std::vector<std::string> segs;
+                segs.reserve(args.size());
+                for (const auto& t : args.tokens()) {
+                    segs.push_back(t);
+                }
+                const auto result = help::render_help(help_registry, segs, options);
+                if (!result.ok) {
+                    return CommandResult::failure(result.text);
+                }
+                return CommandResult::success(result.text);
+            });
+        help_registry.add_command(CommandSpec{
+            .canonical_path = CommandPath{"help"},
+            .domain = "core",
+            .summary = "Show shell help",
+            .usage = {"help", "help <command...>"},
+            .examples = {"help", "help status"}
+        });
+
+        commands.add_command(command::CommandPath{"status"}, cmd_status);
+        help_registry.add_command(CommandSpec{
+            .canonical_path = CommandPath{"status"},
+            .domain = "core",
+            .summary = "Show current shell session status",
+            .usage = {"status"}
+        });
+
+        commands.add_command(command::CommandPath{"reset"}, cmd_reset);
+        help_registry.add_command(CommandSpec{
+            .canonical_path = CommandPath{"reset"},
+            .domain = "core",
+            .summary = "Reset the shell session to its default empty state",
+            .usage = {"reset"}
+        });
+
+        commands.add_command(command::CommandPath{"quit"}, cmd_quit);
+        commands.add_alias(command::CommandPath{"exit"}, command::CommandPath{"quit"});
+        help_registry.add_command(CommandSpec{
+            .canonical_path = CommandPath{"quit"},
+            .domain = "core",
+            .summary = "Request shell termination",
+            .usage = {"quit", "exit"},
+            .notes = {"The alias 'exit' is equivalent to quit."},
+            .aliases = {CommandPath{"exit"}}
+        });
+    }
+
+} // namespace tonb::cad2d::shell::commands

--- a/shell/cad2d/src/shell_app.cxx
+++ b/shell/cad2d/src/shell_app.cxx
@@ -1,17 +1,74 @@
 #include <tonb/cad2d/shell/shell_app.hxx>
 
+#include <utility>
+
+#include <tonb/cad2d/shell/command/command_context.hxx>
+#include <tonb/cad2d/shell/commands/shell_cmd_core.hxx>
+#include <tonb/cad2d/shell/shell_tokenise.hxx>
+
 namespace tonb::cad2d::shell {
+
+    ShellApp::ShellApp() {
+        register_core_commands_();
+    }
 
     std::string_view ShellApp::module_name() noexcept {
         return "TonbCAD2dShell";
     }
 
-    bool ShellApp::has_foundation_support() noexcept {
+    bool ShellApp::has_foundation_support() const noexcept {
 #if defined(TNB_CAD2D_SHELL_HAS_FOUNDATION) && TNB_CAD2D_SHELL_HAS_FOUNDATION
         return true;
 #else
         return false;
 #endif
+    }
+
+    command::CommandRegistry& ShellApp::commands() noexcept {
+        return commands_;
+    }
+
+    const command::CommandRegistry& ShellApp::commands() const noexcept {
+        return commands_;
+    }
+
+    help::HelpRegistry& ShellApp::help() noexcept {
+        return help_;
+    }
+
+    const help::HelpRegistry& ShellApp::help() const noexcept {
+        return help_;
+    }
+
+    ShellSession& ShellApp::session() noexcept {
+        return session_;
+    }
+
+    const ShellSession& ShellApp::session() const noexcept {
+        return session_;
+    }
+
+    command::CommandResult ShellApp::execute_tokens(
+        const std::vector<std::string>& tokens,
+        std::ostream* out,
+        std::ostream* err) {
+        const command::CommandContext context{&session_, out, err};
+        return commands_.dispatch(tokens, context);
+    }
+
+    command::CommandResult ShellApp::execute_line(
+        std::string_view line,
+        std::ostream* out,
+        std::ostream* err) {
+        const auto tokenised = tokenise_command_line(line);
+        if (!tokenised.ok) {
+            return command::CommandResult::failure(tokenised.error);
+        }
+        return execute_tokens(tokenised.tokens, out, err);
+    }
+
+    void ShellApp::register_core_commands_() {
+        commands::register_core_commands(commands_, help_);
     }
 
 } // namespace tonb::cad2d::shell

--- a/tests/shell/cad2d/CMakeLists.txt
+++ b/tests/shell/cad2d/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(test_shell_cad2d_validate
         command_registry_tests.cxx
         help_register_tests.cxx
         shell_tokenise_tests.cxx
+        shell_core_commands_tests.cxx
 )
 
 target_link_libraries(test_shell_cad2d_validate PRIVATE

--- a/tests/shell/cad2d/shell_core_commands_tests.cxx
+++ b/tests/shell/cad2d/shell_core_commands_tests.cxx
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include <tonb/cad2d/shell/shell_app.hxx>
+
+namespace tonb::cad2d::shell {
+namespace {
+
+TEST(ShellCoreCommandsTests, StatusReportsEmptySessionCorrectly) {
+    ShellApp app;
+
+    const auto result = app.execute_line("status");
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_NE(result.message.find("curve stores: 0"), std::string::npos);
+    EXPECT_NE(result.message.find("shapes: 0"), std::string::npos);
+    EXPECT_NE(result.message.find("active shape: <none>"), std::string::npos);
+    EXPECT_NE(result.message.find("active curve store: <none>"), std::string::npos);
+}
+
+TEST(ShellCoreCommandsTests, ResetClearsExistingObjects) {
+    ShellApp app;
+    app.session().curves().create("C1");
+    app.session().curves().set_active("C1");
+    app.session().shapes().create("S1");
+    app.session().shapes().set_active("S1");
+    app.session().shapes().bind_curve_store("S1", "C1");
+
+    const auto result = app.execute_line("reset");
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_EQ(app.session().curves().size(), 0u);
+    EXPECT_EQ(app.session().shapes().size(), 0u);
+    EXPECT_FALSE(app.session().curves().active_name().has_value());
+    EXPECT_FALSE(app.session().shapes().active_name().has_value());
+    EXPECT_FALSE(app.session().runtime().exit_requested);
+}
+
+TEST(ShellCoreCommandsTests, QuitSetsExitRequestedState) {
+    ShellApp app;
+    EXPECT_FALSE(app.session().runtime().exit_requested);
+
+    const auto result = app.execute_line("quit");
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_TRUE(app.session().runtime().exit_requested);
+}
+
+TEST(ShellCoreCommandsTests, ExitSetsExitRequestedState) {
+    ShellApp app;
+    EXPECT_FALSE(app.session().runtime().exit_requested);
+
+    const auto result = app.execute_line("exit");
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_TRUE(app.session().runtime().exit_requested);
+}
+
+TEST(ShellCoreCommandsTests, HelpExecutesThroughRegistry) {
+    ShellApp app;
+
+    const auto result = app.execute_line("help status");
+
+    ASSERT_TRUE(result.ok);
+    EXPECT_NE(result.message.find("status"), std::string::npos);
+}
+
+} // namespace
+} // namespace tonb::cad2d::shell


### PR DESCRIPTION
- implement the first real user-facing core command family for `shell/cad2d`
- add `help`, `status`, `reset`, `quit`, and `exit` commands routed through the command registry
- integrate `help` with the foundation-backed cad2d help subsystem
- add deterministic session-state reporting through `status`
- add deterministic session clearing through `reset`
- add clean runtime termination control through `quit` and `exit`
- exercise command-alias support in a real command family by mapping `exit` to `quit`
- fix core-command help registration to avoid invalid empty root-namespace insertion against the foundation command registry
- add regression tests for empty-session status, reset behavior, quit/exit termination state, and help execution through the registry
- update the changelog under Unreleased for Issue 6 core-shell-command progress